### PR TITLE
Add getter to PropertyInfo

### DIFF
--- a/src/main/java/io/vertx/codegen/OptionsModel.java
+++ b/src/main/java/io/vertx/codegen/OptionsModel.java
@@ -230,7 +230,9 @@ public class OptionsModel implements Model {
             return;
           }
           VariableElement parameterElt = parameters.get(0);
+
           TypeInfo type = typeFactory.create(parameterElt.asType());
+
           boolean array;
           boolean adder;
           if ("add".equals(prefix)) {
@@ -250,47 +252,91 @@ public class OptionsModel implements Model {
               array = false;
             }
           }
-          switch (type.getKind()) {
-            case PRIMITIVE:
-            case BOXED_PRIMITIVE:
-            case STRING:
-            case OPTIONS:
-            case API:
-            case JSON_OBJECT:
-              break;
-            default:
-              return;
+
+          if (!typeIsOkay(type)) {
+            return;
           }
 
-          boolean declared;
-          Element ownerElt = methodElt.getEnclosingElement();
-          if (ownerElt.equals(modelElt)) {
-            // Handle the case where this methods overrides from another options
-            declared = true;
-            for (TypeMirror superTM : modelElt.getInterfaces()) {
-              DeclaredType superDT = (DeclaredType) superTM;
-              if (superDT.asElement().getAnnotation(Options.class) != null) {
-                for (Element foo : elementUtils.getAllMembers((TypeElement) superDT.asElement())) {
-                  if (foo instanceof ExecutableElement) {
-                    if (elementUtils.overrides(methodElt, (ExecutableElement) foo, modelElt)) {
-                      declared = false;
-                    }
-                  }
-                }
-              }
+          boolean declared = getDeclared(methodElt);
+
+          String getter = null;
+          if (propertyMap.containsKey(name)) {
+            PropertyInfo prop = propertyMap.get(name);
+            getter = prop.getter;
+            if (!prop.type.getName().equals(type.getName())) {
+              throw new GenException(methodElt, "Option " + methodElt + " has a getter / setter with different types");
             }
-          } else {
-            declared = ownerElt.getAnnotation(Options.class) == null;
+          }
+          PropertyInfo property = new PropertyInfo(declared, name, type, methodName, array, adder, getter);
+          propertyMap.put(name, property);
+          return;
+        }
+        case "is":
+        case "get": {
+          if (parameters.size() != 0) {
+            return;
           }
 
-          PropertyInfo property = new PropertyInfo(declared, name, type, methodName, array, adder);
-          if (propertyMap.containsKey(property.name)) {
-            //
+          TypeInfo type = typeFactory.create(methodElt.getReturnType());
+          if (!typeIsOkay(type)) {
+            return;
           }
-          propertyMap.put(property.name, property);
+
+          boolean declared = getDeclared(methodElt);
+          boolean array = false;
+          boolean adder = false;
+          String setter = null;
+          if (propertyMap.containsKey(name)) {
+            PropertyInfo prop = propertyMap.get(name);
+            setter = prop.methodName;
+            if (!prop.type.getName().equals(type.getName())) {
+              throw new GenException(methodElt, "Option " + methodElt + " has a getter / setter with different types");
+            }
+            array = prop.array;
+            adder = prop.adder;
+          }
+          PropertyInfo property = new PropertyInfo(declared, name, type, setter, array, adder, methodName);
+          propertyMap.put(name, property);
           return;
         }
       }
     }
+  }
+
+  private boolean typeIsOkay(TypeInfo type) {
+    switch (type.getKind()) {
+      case PRIMITIVE:
+      case BOXED_PRIMITIVE:
+      case STRING:
+      case OPTIONS:
+      case API:
+      case JSON_OBJECT:
+        return true;
+      default:
+        return false;
+    }
+  }
+  private boolean getDeclared(ExecutableElement methodElt) {
+    boolean declared;
+    Element ownerElt = methodElt.getEnclosingElement();
+    if (ownerElt.equals(modelElt)) {
+      // Handle the case where this methods overrides from another options
+      declared = true;
+      for (TypeMirror superTM : modelElt.getInterfaces()) {
+        DeclaredType superDT = (DeclaredType) superTM;
+        if (superDT.asElement().getAnnotation(Options.class) != null) {
+          for (Element foo : elementUtils.getAllMembers((TypeElement) superDT.asElement())) {
+            if (foo instanceof ExecutableElement) {
+              if (elementUtils.overrides(methodElt, (ExecutableElement) foo, modelElt)) {
+                declared = false;
+              }
+            }
+          }
+        }
+      }
+    } else {
+      declared = ownerElt.getAnnotation(Options.class) == null;
+    }
+    return declared;
   }
 }

--- a/src/main/java/io/vertx/codegen/PropertyInfo.java
+++ b/src/main/java/io/vertx/codegen/PropertyInfo.java
@@ -9,16 +9,18 @@ public class PropertyInfo {
   final String name;
   final TypeInfo type;
   final String methodName;
+  final String getter;
   final boolean array;
   final boolean adder;
 
-  public PropertyInfo(boolean declared, String name, TypeInfo type, String methodName, boolean array, boolean adder) {
+  public PropertyInfo(boolean declared, String name, TypeInfo type, String methodName, boolean array, boolean adder, String getter) {
     this.declared = declared;
     this.name = name;
     this.type = type;
     this.methodName = methodName;
     this.array = array;
     this.adder = adder;
+    this.getter = getter;
   }
 
   public boolean isDeclared() {
@@ -35,6 +37,10 @@ public class PropertyInfo {
 
   public String getMethodName() {
     return methodName;
+  }
+
+  public String getGetter() {
+    return getter;
   }
 
   public boolean isArray() {

--- a/src/test/java/io/vertx/test/codegen/OptionsTest.java
+++ b/src/test/java/io/vertx/test/codegen/OptionsTest.java
@@ -36,6 +36,7 @@ import io.vertx.test.codegen.testoptions.ImportedSubinterface;
 import io.vertx.test.codegen.testoptions.JsonObjectAdder;
 import io.vertx.test.codegen.testoptions.JsonObjectSetter;
 import io.vertx.test.codegen.testoptions.ListBasicSetters;
+import io.vertx.test.codegen.testoptions.OptionWithGetterAndSetter;
 import io.vertx.test.codegen.testoptions.Parameterized;
 import io.vertx.test.codegen.testoptions.SetterNormalizationRules;
 import io.vertx.test.codegen.testoptions.SetterWithNestedOptions;
@@ -133,7 +134,7 @@ public class OptionsTest {
   public void testBasicGetters() throws Exception {
     OptionsModel model = new Generator().generateOptions(BasicGetters.class);
     assertNotNull(model);
-    assertEquals(0, model.getPropertyMap().size());
+    assertEquals(5, model.getPropertyMap().size());
   }
 
   @Test
@@ -318,6 +319,17 @@ public class OptionsTest {
     OptionsModel model = new Generator().generateOptions(ImportedNested.class);
     assertNotNull(model);
     assertEquals(Collections.singleton((TypeInfo.Class) TypeInfo.create(Imported.class)), model.getImportedTypes());
+  }
+
+  @Test
+  public void testOptionWithGetterAndSetter() throws Exception {
+    OptionsModel model = new Generator().generateOptions(OptionWithGetterAndSetter.class);
+    assertNotNull(model);
+    assertEquals(1, model.getPropertyMap().size());
+    PropertyInfo prop = model.getPropertyMap().get("someValue");
+    assertProperty(prop, "someValue", TypeInfo.create(String.class), true, false, false);
+    assertEquals(prop.getGetter(), "getSomeValue");
+    assertEquals(prop.getMethodName(), "setSomeValue");
   }
 
   private static void assertProperty(PropertyInfo property, String expectedName, TypeInfo expectedType,

--- a/src/test/java/io/vertx/test/codegen/testoptions/OptionWithGetterAndSetter.java
+++ b/src/test/java/io/vertx/test/codegen/testoptions/OptionWithGetterAndSetter.java
@@ -1,0 +1,16 @@
+package io.vertx.test.codegen.testoptions;
+
+import io.vertx.codegen.annotations.Options;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author <a href="http://www.campudus.com">Joern Bernhardt</a>
+ */
+@Options
+public interface OptionWithGetterAndSetter {
+
+  OptionWithGetterAndSetter setSomeValue(String value);
+
+  String getSomeValue();
+
+}


### PR DESCRIPTION
I'd like to be able to call the Java getter of a property from Vert.x Scala, as "name" is not working if Java doesn't make the property public for all.

It would be even better to rename `methodName` into `setter` but I'm unsure how many templates rely on `methodName` currently.