### PR TITLE
Added support for list and set of @DataObject

### DIFF
--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -303,7 +303,7 @@ public class ClassModel implements Model {
       TypeInfo raw = type.getRaw();
       if (raw.getName().equals(List.class.getName()) || raw.getName().equals(Set.class.getName())) {
         TypeInfo elementType = ((TypeInfo.Parameterized) type).getArgs().get(0);
-        if (elementType.getKind().basic || elementType.getKind().json || isVertxGenInterface(elementType)) {
+        if (elementType.getKind().basic || elementType.getKind().json || isVertxGenInterface(elementType) || isDataObjectType(elementType)) {
           return true;
         }
       }
@@ -312,12 +312,12 @@ public class ClassModel implements Model {
   }
 
   protected boolean isLegalListSetMapParam(TypeInfo type) {
-    // List<T> and Set<T> are also legal for returns and params if T = basic type, json, or @VertxGen
+    // List<T> and Set<T> are also legal for params if T = basic type, json, @VertxGen, @DataObject
     // Map<K,V> is also legal for returns and params if K is a String and V is a basic type, json, or a @VertxGen interface
     if (rawTypeIs(type, List.class, Set.class, Map.class)) {
       TypeInfo argument = ((TypeInfo.Parameterized) type).getArgs().get(0);
       if (type.getKind() != ClassKind.MAP) {
-        if (argument.getKind().basic || argument.getKind().json || isVertxGenInterface(argument)) {
+        if (argument.getKind().basic || argument.getKind().json || isVertxGenInterface(argument) || isDataObjectType(argument)) {
           return true;
         }
       } else if (argument.getKind() == ClassKind.STRING) { // Only allow Map's with String's for keys

--- a/src/main/java/io/vertx/codegen/ProxyModel.java
+++ b/src/main/java/io/vertx/codegen/ProxyModel.java
@@ -175,7 +175,7 @@ public class ProxyModel extends ClassModel {
     if (type instanceof TypeInfo.Parameterized) {
       if (type.getKind() == ClassKind.LIST || type.getKind() == ClassKind.SET) {
         TypeInfo elementType = ((TypeInfo.Parameterized) type).getArgs().get(0);
-        if (elementType.getKind().basic || elementType.getKind().json) {
+        if (elementType.getKind().basic || elementType.getKind().json || elementType.getKind() == ClassKind.DATA_OBJECT) {
           return true;
         }
       }
@@ -189,7 +189,7 @@ public class ProxyModel extends ClassModel {
     TypeInfo raw = type.getRaw();
     if (raw.getName().equals(List.class.getName()) || raw.getName().equals(Set.class.getName())) {
       TypeInfo argument = ((TypeInfo.Parameterized) type).getArgs().get(0);
-      if (argument.getKind().basic || argument.getKind().json) {
+      if (argument.getKind().basic || argument.getKind().json || argument.getKind() == ClassKind.DATA_OBJECT) {
         return true;
       }
     } else if (raw.getName().equals(Map.class.getName())) {

--- a/src/tck/java/io/vertx/codegen/testmodel/TestInterface.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/TestInterface.java
@@ -47,9 +47,9 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   void methodWithNullDataObjectParam(TestDataObject dataObject);
 
-  void methodWithListParams(List<String> listString, List<Byte> listByte, List<Short> listShort, List<Integer> listInt, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<RefedInterface1> listVertxGen);
+  void methodWithListParams(List<String> listString, List<Byte> listByte, List<Short> listShort, List<Integer> listInt, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<RefedInterface1> listVertxGen, List<TestDataObject> listDataObject);
 
-  void methodWithSetParams(Set<String> setString, Set<Byte> setByte, Set<Short> setShort, Set<Integer> setInt, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<RefedInterface1> setVertxGen);
+  void methodWithSetParams(Set<String> setString, Set<Byte> setByte, Set<Short> setShort, Set<Integer> setInt, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<RefedInterface1> setVertxGen, Set<TestDataObject> setDataObject);
 
   void methodWithMapParams(Map<String, String> mapString, Map<String, Byte> mapByte, Map<String, Short> mapShort, Map<String, Integer> mapInt, Map<String, Long> mapLong, Map<String, JsonObject> mapJsonObject, Map<String, JsonArray> mapJsonArray, Map<String, RefedInterface1> mapVertxGen);
 
@@ -108,6 +108,14 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
   void methodWithHandlerAsyncResultSetJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler);
 
   void methodWithHandlerAsyncResultSetNullJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler);
+
+  void methodWithHandlerAsyncResultListDataObject(Handler<AsyncResult<List<TestDataObject>>> listHandler);
+
+  void methodWithHandlerAsyncResultListNullDataObject(Handler<AsyncResult<List<TestDataObject>>> listHandler);
+
+  void methodWithHandlerAsyncResultSetDataObject(Handler<AsyncResult<Set<TestDataObject>>> setHandler);
+
+  void methodWithHandlerAsyncResultSetNullDataObject(Handler<AsyncResult<Set<TestDataObject>>> setHandler);
 
   void methodWithHandlerUserTypes(Handler<RefedInterface1> handler);
 

--- a/src/tck/java/io/vertx/codegen/testmodel/TestInterfaceImpl.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/TestInterfaceImpl.java
@@ -11,10 +11,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -242,7 +244,7 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
-  public void methodWithListParams(List<String> listString, List<Byte> listByte, List<Short> listShort, List<Integer> listInt, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<RefedInterface1> listVertxGen) {
+  public void methodWithListParams(List<String> listString, List<Byte> listByte, List<Short> listShort, List<Integer> listInt, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<RefedInterface1> listVertxGen, List<TestDataObject> listDataObject) {
     assertEquals("foo", listString.get(0));
     assertEquals("bar", listString.get(1));
     assertEquals((byte)2, listByte.get(0).byteValue());
@@ -260,10 +262,12 @@ public class TestInterfaceImpl implements TestInterface {
     assertEquals(new JsonArray().add("blah"), listJsonArray.get(1));
     assertEquals("foo", listVertxGen.get(0).getString());
     assertEquals("bar", listVertxGen.get(1).getString());
+    assertEquals(new JsonObject().put("foo", "String 1").put("bar", 1).put("wibble", 1.1), listDataObject.get(0).toJson());
+    assertEquals(new JsonObject().put("foo", "String 2").put("bar", 2).put("wibble", 2.2), listDataObject.get(1).toJson());
   }
 
   @Override
-  public void methodWithSetParams(Set<String> setString, Set<Byte> setByte, Set<Short> setShort, Set<Integer> setInt, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<RefedInterface1> setVertxGen) {
+  public void methodWithSetParams(Set<String> setString, Set<Byte> setByte, Set<Short> setShort, Set<Integer> setInt, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<RefedInterface1> setVertxGen, Set<TestDataObject> setDataObject) {
     assertTrue(setString.contains("foo"));
     assertTrue(setString.contains("bar"));
     assertTrue(setByte.contains((byte)2));
@@ -280,6 +284,10 @@ public class TestInterfaceImpl implements TestInterface {
     assertTrue(setJsonArray.contains(new JsonArray().add("blah")));
     assertTrue(setVertxGen.contains(new RefedInterface1Impl().setString("foo")));
     assertTrue(setVertxGen.contains(new RefedInterface1Impl().setString("bar")));
+    assertEquals(2, setDataObject.size());
+    Set<JsonObject> setDataObjectJson = setDataObject.stream().map(d -> d.toJson()).collect(Collectors.toSet());
+    assertTrue(setDataObjectJson.contains(new JsonObject().put("foo", "String 1").put("bar", 1).put("wibble", 1.1)));
+    assertTrue(setDataObjectJson.contains(new JsonObject().put("foo", "String 2").put("bar", 2).put("wibble", 2.2)));
   }
 
   @Override
@@ -483,6 +491,32 @@ public class TestInterfaceImpl implements TestInterface {
   public void methodWithHandlerAsyncResultSetNullJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler) {
     Set<JsonArray> set = Collections.singleton(null);
     listHandler.handle(Future.succeededFuture(set));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultListDataObject(Handler<AsyncResult<List<TestDataObject>>> listHandler) {
+    List<TestDataObject> list = 
+        Arrays.asList(new TestDataObject().setFoo("String 1").setBar(1).setWibble(1.1), new TestDataObject().setFoo("String 2").setBar(2).setWibble(2.2));
+    listHandler.handle(Future.succeededFuture(list));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultListNullDataObject(Handler<AsyncResult<List<TestDataObject>>> listHandler) {
+    List<TestDataObject> list = Collections.singletonList(null);
+	  listHandler.handle(Future.succeededFuture(list));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultSetDataObject(Handler<AsyncResult<Set<TestDataObject>>> setHandler) {
+    Set<TestDataObject> set = 
+        new HashSet<>(Arrays.asList(new TestDataObject().setFoo("String 1").setBar(1).setWibble(1.1), new TestDataObject().setFoo("String 2").setBar(2).setWibble(2.2)));
+    setHandler.handle(Future.succeededFuture(set));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultSetNullDataObject(Handler<AsyncResult<Set<TestDataObject>>> setHandler) {
+    Set<TestDataObject> set = Collections.singleton(null);
+    setHandler.handle(Future.succeededFuture(set));
   }
 
   @Override

--- a/src/test/java/io/vertx/test/codegen/GeneratorTest.java
+++ b/src/test/java/io/vertx/test/codegen/GeneratorTest.java
@@ -466,13 +466,14 @@ public class GeneratorTest {
     String methodName = "methodWithListParams";
 
     Consumer<MethodInfo> checker = (method) -> {
-      checkMethod(method, methodName, null, MethodKind.OTHER, "void", false, false, false, 5);
+      checkMethod(method, methodName, null, MethodKind.OTHER, "void", false, false, false, 6);
       List<ParamInfo> params = method.getParams();
       checkClassParam(params.get(0), "listString", "java.util.List<java.lang.String>", ClassKind.LIST);
       checkClassParam(params.get(1), "listLong", "java.util.List<java.lang.Long>", ClassKind.LIST);
       checkClassParam(params.get(2), "listJsonObject", "java.util.List<io.vertx.core.json.JsonObject>", ClassKind.LIST);
       checkClassParam(params.get(3), "listJsonArray", "java.util.List<io.vertx.core.json.JsonArray>", ClassKind.LIST);
       checkClassParam(params.get(4), "listVertxGen", "java.util.List<" + VertxGenClass1.class.getName() + ">", ClassKind.LIST);
+      checkClassParam(params.get(5), "listDataObject", "java.util.List<" + TestDataObject.class.getName() + ">", ClassKind.LIST);
     };
 
     MethodInfo method = model.getMethods().get(0);
@@ -491,13 +492,14 @@ public class GeneratorTest {
     String methodName = "methodWithSetParams";
 
     Consumer<MethodInfo> checker = (method) -> {
-      checkMethod(method, methodName, null, MethodKind.OTHER, "void", false, false, false, 5);
+      checkMethod(method, methodName, null, MethodKind.OTHER, "void", false, false, false, 6);
       List<ParamInfo> params = method.getParams();
       checkClassParam(params.get(0), "setString", "java.util.Set<java.lang.String>", ClassKind.SET);
       checkClassParam(params.get(1), "setLong", "java.util.Set<java.lang.Long>", ClassKind.SET);
       checkClassParam(params.get(2), "setJsonObject", "java.util.Set<io.vertx.core.json.JsonObject>", ClassKind.SET);
       checkClassParam(params.get(3), "setJsonArray", "java.util.Set<io.vertx.core.json.JsonArray>", ClassKind.SET);
       checkClassParam(params.get(4), "setVertxGen", "java.util.Set<" + VertxGenClass1.class.getName() + ">", ClassKind.SET);
+      checkClassParam(params.get(5), "setDataObject", "java.util.Set<" + TestDataObject.class.getName() + ">", ClassKind.SET);
     };
 
     MethodInfo method = model.getMethods().get(0);
@@ -601,7 +603,7 @@ public class GeneratorTest {
     String methodName = "methodWithHandlerParams";
 
     Consumer<MethodInfo> checker = (method) -> {
-      checkMethod(method, methodName, null, MethodKind.FUTURE, "void", false, false, false, 37);
+      checkMethod(method, methodName, null, MethodKind.FUTURE, "void", false, false, false, 39);
       List<ParamInfo> params = method.getParams();
       checkClassParam(params.get(0), "byteHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.lang.Byte>>", ClassKind.HANDLER);
       checkClassParam(params.get(1), "shortHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.lang.Short>>", ClassKind.HANDLER);
@@ -640,6 +642,8 @@ public class GeneratorTest {
       checkClassParam(params.get(34), "setJsonArrayHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.util.Set<" + JsonArray.class.getName() + ">>>", ClassKind.HANDLER);
       checkClassParam(params.get(35), "voidHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.lang.Void>>", ClassKind.HANDLER);
       checkClassParam(params.get(36), "dataObjectHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<" + TestDataObject.class.getName() + ">>", ClassKind.HANDLER);
+      checkClassParam(params.get(37), "listDataObjectHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.util.List<" + TestDataObject.class.getName() + ">>>", ClassKind.HANDLER);
+      checkClassParam(params.get(38), "setDataObjectHandler", "io.vertx.core.Handler<io.vertx.core.AsyncResult<java.util.Set<" + TestDataObject.class.getName() + ">>>", ClassKind.HANDLER);
     };
 
     MethodInfo method = model.getMethods().get(0);

--- a/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidHandlerAsyncResultParams.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidHandlerAsyncResultParams.java
@@ -28,5 +28,6 @@ public interface MethodWithValidHandlerAsyncResultParams {
                                Handler<AsyncResult<Set<Long>>> setLongHandler, Handler<AsyncResult<Set<Float>>> setFloatHandler, Handler<AsyncResult<Set<Double>>> setDoubleHandler,
                                Handler<AsyncResult<Set<Boolean>>> setBooleanHandler, Handler<AsyncResult<Set<Character>>> setCharHandler, Handler<AsyncResult<Set<String>>> setStrHandler,
                                Handler<AsyncResult<Set<VertxGenClass1>>> setVertxGenHandler, Handler<AsyncResult<Set<JsonObject>>> setJsonObjectHandler, Handler<AsyncResult<Set<JsonArray>>> setJsonArrayHandler,
-                               Handler<AsyncResult<Void>> voidHandler, Handler<AsyncResult<TestDataObject>> dataObjectHandler);
+                               Handler<AsyncResult<Void>> voidHandler, Handler<AsyncResult<TestDataObject>> dataObjectHandler, Handler<AsyncResult<List<TestDataObject>>> listDataObjectHandler,
+                               Handler<AsyncResult<Set<TestDataObject>>> setDataObjectHandler);
 }

--- a/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidListParams.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidListParams.java
@@ -17,6 +17,7 @@
 package io.vertx.test.codegen.testapi;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.testmodel.TestDataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -28,5 +29,6 @@ import java.util.List;
 @VertxGen
 public interface MethodWithValidListParams {
 
-  void methodWithListParams(List<String> listString, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<VertxGenClass1> listVertxGen);
+  void methodWithListParams(List<String> listString, List<Long> listLong, List<JsonObject> listJsonObject, List<JsonArray> listJsonArray, List<VertxGenClass1> listVertxGen,
+      List<TestDataObject> listDataObject);
 }

--- a/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidSetParams.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/MethodWithValidSetParams.java
@@ -17,6 +17,7 @@
 package io.vertx.test.codegen.testapi;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.testmodel.TestDataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -28,6 +29,6 @@ import java.util.Set;
 @VertxGen
 public interface MethodWithValidSetParams {
 
-  void methodWithSetParams(Set<String> setString, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<VertxGenClass1> setVertxGen);
-
+  void methodWithSetParams(Set<String> setString, Set<Long> setLong, Set<JsonObject> setJsonObject, Set<JsonArray> setJsonArray, Set<VertxGenClass1> setVertxGen,
+      Set<TestDataObject> setDataObject);
 }


### PR DESCRIPTION
Added support for list and set of @DataObject in method parameters and async result handler.
This pull request depends on https://github.com/vert-x3/vertx-service-proxy/pull/12