### PR TITLE
Add methods for testing of nested JsonObject/JsonArray structures.

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -10,6 +10,8 @@ public class JsonArray implements Iterable<Object> {
   public int size() { throw new UnsupportedOperationException(); }
   public String getString(final int index) { throw new UnsupportedOperationException(); }
   public JsonArray add(String str) { throw new UnsupportedOperationException(); }
+  public JsonArray add(JsonObject obj) { throw new UnsupportedOperationException(); }
+  public JsonArray add(JsonArray array) { throw new UnsupportedOperationException(); }
   public Iterator<Object> iterator() { throw new UnsupportedOperationException(); }
 
 }

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -14,6 +14,8 @@ public class JsonObject  {
   public JsonObject getJsonObject(String name) { throw new UnsupportedOperationException(); }
   public String getString(String name) { throw new UnsupportedOperationException(); }
   public String getString(String name, String def) { throw new UnsupportedOperationException(); }
+  public JsonObject put(String fieldName, JsonObject value) { throw new UnsupportedOperationException(); }
+  public JsonObject put(String fieldName, JsonArray value) { throw new UnsupportedOperationException(); }
   public JsonObject put(String fieldName, String value) { throw new UnsupportedOperationException(); }
   public JsonObject put(String fieldName, Integer value) { throw new UnsupportedOperationException(); }
   public JsonObject put(String fieldName, Long value) { throw new UnsupportedOperationException(); }

--- a/src/tck/java/io/vertx/codegen/testmodel/TestInterface.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/TestInterface.java
@@ -73,17 +73,25 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   void methodWithHandlerListNullJsonObject(Handler<List<JsonObject>> listHandler);
 
+  void methodWithHandlerListComplexJsonObject(Handler<List<JsonObject>> listHandler);
+
   void methodWithHandlerSetJsonObject(Handler<Set<JsonObject>> listHandler);
 
   void methodWithHandlerSetNullJsonObject(Handler<Set<JsonObject>> listHandler);
+
+  void methodWithHandlerSetComplexJsonObject(Handler<Set<JsonObject>> listHandler);
 
   void methodWithHandlerListJsonArray(Handler<List<JsonArray>> listHandler);
 
   void methodWithHandlerListNullJsonArray(Handler<List<JsonArray>> listHandler);
 
+  void methodWithHandlerListComplexJsonArray(Handler<List<JsonArray>> listHandler);
+
   void methodWithHandlerSetJsonArray(Handler<Set<JsonArray>> listHandler);
 
   void methodWithHandlerSetNullJsonArray(Handler<Set<JsonArray>> listHandler);
+
+  void methodWithHandlerSetComplexJsonArray(Handler<Set<JsonArray>> setHandler);
 
   void methodWithHandlerListDataObject(Handler<List<TestDataObject>> listHandler);
 
@@ -105,17 +113,25 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   void methodWithHandlerAsyncResultListNullJsonObject(Handler<AsyncResult<List<JsonObject>>> listHandler);
 
+  void methodWithHandlerAsyncResultListComplexJsonObject(Handler<AsyncResult<List<JsonObject>>> listHandler);
+
   void methodWithHandlerAsyncResultSetJsonObject(Handler<AsyncResult<Set<JsonObject>>> listHandler);
 
   void methodWithHandlerAsyncResultSetNullJsonObject(Handler<AsyncResult<Set<JsonObject>>> listHandler);
+
+  void methodWithHandlerAsyncResultSetComplexJsonObject(Handler<AsyncResult<Set<JsonObject>>> listHandler);
 
   void methodWithHandlerAsyncResultListJsonArray(Handler<AsyncResult<List<JsonArray>>> listHandler);
 
   void methodWithHandlerAsyncResultListNullJsonArray(Handler<AsyncResult<List<JsonArray>>> listHandler);
 
+  void methodWithHandlerAsyncResultListComplexJsonArray(Handler<AsyncResult<List<JsonArray>>> listHandler);
+
   void methodWithHandlerAsyncResultSetJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler);
 
   void methodWithHandlerAsyncResultSetNullJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler);
+
+  void methodWithHandlerAsyncResultSetComplexJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler);
 
   void methodWithHandlerAsyncResultListDataObject(Handler<AsyncResult<List<TestDataObject>>> listHandler);
 
@@ -206,9 +222,13 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   JsonObject methodWithNullJsonObjectReturn();
 
+  JsonObject methodWithComplexJsonObjectReturn();
+
   JsonArray methodWithJsonArrayReturn();
 
   JsonArray methodWithNullJsonArrayReturn();
+
+  JsonArray methodWithComplexJsonArrayReturn();
 
   void methodWithJsonParams(JsonObject jsonObject, JsonArray jsonArray);
 
@@ -218,13 +238,19 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   void methodWithHandlerNullJson(Handler<JsonObject> jsonObjectHandler, Handler<JsonArray> jsonArrayHandler);
 
+  void methodWithHandlerComplexJson(Handler<JsonObject> jsonObjectHandler, Handler<JsonArray> jsonArrayHandler);
+
   void methodWithHandlerAsyncResultJsonObject(Handler<AsyncResult<JsonObject>> handler);
 
   void methodWithHandlerAsyncResultNullJsonObject(Handler<AsyncResult<JsonObject>> handler);
 
+  void methodWithHandlerAsyncResultComplexJsonObject(Handler<AsyncResult<JsonObject>> handler);
+
   void methodWithHandlerAsyncResultJsonArray(Handler<AsyncResult<JsonArray>> handler);
 
   void methodWithHandlerAsyncResultNullJsonArray(Handler<AsyncResult<JsonArray>> handler);
+
+  void methodWithHandlerAsyncResultComplexJsonArray(Handler<AsyncResult<JsonArray>> handler);
 
   Map<String, String> methodWithMapReturn(Handler<String> handler);
 
@@ -248,7 +274,11 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   Map<String, JsonObject> methodWithMapJsonObjectReturn(Handler<String> handler);
 
+  Map<String, JsonObject> methodWithMapComplexJsonObjectReturn(Handler<String> handler);
+
   Map<String, JsonArray> methodWithMapJsonArrayReturn(Handler<String> handler);
+
+  Map<String, JsonArray> methodWithMapComplexJsonArrayReturn(Handler<String> handler);
 
   Map<String, String> methodWithNullMapReturn();
 
@@ -262,8 +292,12 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   List<JsonObject> methodWithListJsonObjectReturn();
 
+  List<JsonObject> methodWithListComplexJsonObjectReturn();
+
   List<JsonArray> methodWithListJsonArrayReturn();
 
+  List<JsonArray> methodWithListComplexJsonArrayReturn();
+  
   List<String> methodWithNullListReturn();
 
 
@@ -276,7 +310,11 @@ public interface TestInterface extends SuperInterface1, SuperInterface2 {
 
   Set<JsonObject> methodWithSetJsonObjectReturn();
 
+  Set<JsonObject> methodWithSetComplexJsonObjectReturn();
+
   Set<JsonArray> methodWithSetJsonArrayReturn();
+
+  Set<JsonArray> methodWithSetComplexJsonArrayReturn();
 
   Set<String> methodWithNullSetReturn();
 

--- a/src/tck/java/io/vertx/codegen/testmodel/TestInterfaceImpl.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/TestInterfaceImpl.java
@@ -1,5 +1,10 @@
 package io.vertx.codegen.testmodel;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -11,14 +16,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -386,6 +388,12 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerListComplexJsonObject(Handler<List<JsonObject>> listHandler) {
+    List<JsonObject> list = Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue")));
+    listHandler.handle(list);    
+  }
+
+  @Override
   public void methodWithHandlerSetJsonObject(Handler<Set<JsonObject>> setHandler) {
     Set<JsonObject> set = new LinkedHashSet<>(Arrays.asList(new JsonObject().put("cheese", "stilton"), new JsonObject().put("socks", "tartan")));
     setHandler.handle(set);
@@ -394,6 +402,12 @@ public class TestInterfaceImpl implements TestInterface {
   @Override
   public void methodWithHandlerSetNullJsonObject(Handler<Set<JsonObject>> setHandler) {
     Set<JsonObject> set = Collections.singleton(null);
+    setHandler.handle(set);
+  }
+
+  @Override
+  public void methodWithHandlerSetComplexJsonObject(Handler<Set<JsonObject>> setHandler) {
+    Set<JsonObject> set = new LinkedHashSet<>(Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue"))));
     setHandler.handle(set);
   }
 
@@ -410,6 +424,12 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerListComplexJsonArray(Handler<List<JsonArray>> listHandler) {
+    List<JsonArray> list = Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye")));
+    listHandler.handle(list);
+  }
+
+  @Override
   public void methodWithHandlerSetJsonArray(Handler<Set<JsonArray>> listHandler) {
     Set<JsonArray> set = new LinkedHashSet<>(Arrays.asList(new JsonArray().add("green").add("blue"), new JsonArray().add("yellow").add("purple")));
     listHandler.handle(set);
@@ -419,6 +439,13 @@ public class TestInterfaceImpl implements TestInterface {
   public void methodWithHandlerSetNullJsonArray(Handler<Set<JsonArray>> listHandler) {
     Set<JsonArray> set = Collections.singleton(null);
     listHandler.handle(set);
+  }
+
+  @Override
+  public void methodWithHandlerSetComplexJsonArray(Handler<Set<JsonArray>> setHandler) {
+    List<JsonArray> list = Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye")));
+    Set<JsonArray> set = new LinkedHashSet<>(list);
+    setHandler.handle(set);
   }
 
   @Override
@@ -484,6 +511,12 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerAsyncResultListComplexJsonObject(Handler<AsyncResult<List<JsonObject>>> listHandler) {
+    List<JsonObject> list = Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue")));
+    listHandler.handle(Future.succeededFuture(list));
+  }
+
+  @Override
   public void methodWithHandlerAsyncResultSetJsonObject(Handler<AsyncResult<Set<JsonObject>>> setHandler) {
     Set<JsonObject> set = new LinkedHashSet<>(Arrays.asList(new JsonObject().put("cheese", "stilton"), new JsonObject().put("socks", "tartan")));
     setHandler.handle(Future.succeededFuture(set));
@@ -492,6 +525,12 @@ public class TestInterfaceImpl implements TestInterface {
   @Override
   public void methodWithHandlerAsyncResultSetNullJsonObject(Handler<AsyncResult<Set<JsonObject>>> setHandler) {
     Set<JsonObject> set = Collections.singleton(null);
+    setHandler.handle(Future.succeededFuture(set));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultSetComplexJsonObject(Handler<AsyncResult<Set<JsonObject>>> setHandler) {
+    Set<JsonObject> set = new LinkedHashSet<>(Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue"))));
     setHandler.handle(Future.succeededFuture(set));
   }
 
@@ -508,6 +547,12 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerAsyncResultListComplexJsonArray(Handler<AsyncResult<List<JsonArray>>> listHandler) {
+    List<JsonArray> list = Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye")));
+    listHandler.handle(Future.succeededFuture(list));
+  }
+
+  @Override
   public void methodWithHandlerAsyncResultSetJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler) {
     Set<JsonArray> set = new LinkedHashSet<>(Arrays.asList(new JsonArray().add("green").add("blue"), new JsonArray().add("yellow").add("purple")));
     listHandler.handle(Future.succeededFuture(set));
@@ -516,6 +561,12 @@ public class TestInterfaceImpl implements TestInterface {
   @Override
   public void methodWithHandlerAsyncResultSetNullJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler) {
     Set<JsonArray> set = Collections.singleton(null);
+    listHandler.handle(Future.succeededFuture(set));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultSetComplexJsonArray(Handler<AsyncResult<Set<JsonArray>>> listHandler) {
+    Set<JsonArray> set = new LinkedHashSet<>(Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye"))));
     listHandler.handle(Future.succeededFuture(set));
   }
 
@@ -775,6 +826,9 @@ public class TestInterfaceImpl implements TestInterface {
         // Some languages will convert to Long
         return (U) (new JsonObject().put("foo", "hello").put("bar", 123L));
       }
+      case "JsonObjectComplex": {
+        return (U) (new JsonObject().put("outer", new JsonObject().put("foo", "hello")).put("bar", new JsonArray().add("this").add("that")));
+      }
       case "JsonArray": {
         return (U) (new JsonArray().add("foo").add("bar").add("wib"));
       }
@@ -831,6 +885,11 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public JsonObject methodWithComplexJsonObjectReturn() {
+    return new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue"));
+  }
+
+  @Override
   public JsonArray methodWithJsonArrayReturn() {
     return new JsonArray().add("socks").add("shoes");
   }
@@ -838,6 +897,11 @@ public class TestInterfaceImpl implements TestInterface {
   @Override
   public JsonArray methodWithNullJsonArrayReturn() {
     return null;
+  }
+
+  @Override
+  public JsonArray methodWithComplexJsonArrayReturn() {
+    return new JsonArray().add(new JsonObject().put("foo", "hello")).add(new JsonObject().put("bar", "bye"));
   }
 
   @Override
@@ -873,6 +937,14 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerComplexJson(Handler<JsonObject> jsonObjectHandler, Handler<JsonArray> jsonArrayHandler) {
+    assertNotNull(jsonObjectHandler);
+    assertNotNull(jsonArrayHandler);
+    jsonObjectHandler.handle(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue")));
+    jsonArrayHandler.handle(new JsonArray().add(new JsonArray().add(new JsonObject().put("foo", "hello"))).add(new JsonArray().add(new JsonObject().put("bar", "bye"))));
+  }
+
+  @Override
   public void methodWithHandlerAsyncResultJsonObject(Handler<AsyncResult<JsonObject>> handler) {
     assertNotNull(handler);
     handler.handle(Future.succeededFuture(new JsonObject().put("cheese", "stilton")));
@@ -885,6 +957,12 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public void methodWithHandlerAsyncResultComplexJsonObject(Handler<AsyncResult<JsonObject>> handler) {
+    assertNotNull(handler);
+    handler.handle(Future.succeededFuture(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue"))));
+  }
+  
+  @Override
   public void methodWithHandlerAsyncResultJsonArray(Handler<AsyncResult<JsonArray>> handler) {
     assertNotNull(handler);
     handler.handle(Future.succeededFuture(new JsonArray().add("socks").add("shoes")));
@@ -894,6 +972,12 @@ public class TestInterfaceImpl implements TestInterface {
   public void methodWithHandlerAsyncResultNullJsonArray(Handler<AsyncResult<JsonArray>> handler) {
     assertNotNull(handler);
     handler.handle(Future.succeededFuture(null));
+  }
+
+  @Override
+  public void methodWithHandlerAsyncResultComplexJsonArray(Handler<AsyncResult<JsonArray>> handler) {
+    assertNotNull(handler);
+    handler.handle(Future.succeededFuture(new JsonArray().add(new JsonObject().put("foo", "hello")).add(new JsonObject().put("bar", "bye"))));
   }
 
   @Override
@@ -927,9 +1011,23 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public Map<String, JsonObject> methodWithMapComplexJsonObjectReturn(Handler<String> handler) {
+    Map<String, JsonObject> map = new JsonObjectHandlerTestMap(handler);
+    map.put("foo", new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue")));
+    return map;
+  }
+
+  @Override
   public Map<String, JsonArray> methodWithMapJsonArrayReturn(Handler<String> handler) {
     Map<String, JsonArray> map = new JsonArrayHandlerTestMap(handler);
     map.put("foo", new JsonArray().add("wibble"));
+    return map;
+  }
+
+  @Override
+  public Map<String, JsonArray> methodWithMapComplexJsonArrayReturn(Handler<String> handler) {
+    Map<String, JsonArray> map = new JsonArrayHandlerTestMap(handler);
+    map.put("foo", new JsonArray().add(new JsonObject().put("foo", "hello")).add(new JsonObject().put("bar", "bye")));
     return map;
   }
 
@@ -1025,8 +1123,18 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public List<JsonObject> methodWithListComplexJsonObjectReturn() {
+    return Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue")));
+  }
+  
+  @Override
   public List<JsonArray> methodWithListJsonArrayReturn() {
     return Arrays.asList(new JsonArray().add("foo"), new JsonArray().add("blah"));
+  }
+
+  @Override
+  public List<JsonArray> methodWithListComplexJsonArrayReturn() {
+    return Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye")));
   }
 
   @Override
@@ -1050,8 +1158,18 @@ public class TestInterfaceImpl implements TestInterface {
   }
 
   @Override
+  public Set<JsonObject> methodWithSetComplexJsonObjectReturn() {
+    return new LinkedHashSet<>(Arrays.asList(new JsonObject().put("outer", new JsonObject().put("socks", "tartan")).put("list", new JsonArray().add("yellow").add("blue"))));
+  }
+
+  @Override
   public Set<JsonArray> methodWithSetJsonArrayReturn() {
     return new LinkedHashSet<>(Arrays.asList(new JsonArray().add("foo"), new JsonArray().add("blah")));
+  }
+
+  @Override
+  public Set<JsonArray> methodWithSetComplexJsonArrayReturn() {
+    return new LinkedHashSet<>(Arrays.asList(new JsonArray().add(new JsonObject().put("foo", "hello")), new JsonArray().add(new JsonObject().put("bar", "bye"))));
   }
 
   @Override
@@ -1306,5 +1424,6 @@ public class TestInterfaceImpl implements TestInterface {
       return super.put(key, value);
     }
   }
+
 }
 


### PR DESCRIPTION
The existing methods use flat object/array instances.  These add nested structures so the language bindings can be verified over a full object graph.