### PR TITLE
Added annotation processor service declaration

### DIFF
--- a/src/main/assembly/tck.xml
+++ b/src/main/assembly/tck.xml
@@ -16,4 +16,10 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>
+  <files>
+    <file>
+      <source>${project.basedir}/src/main/resources/META-INF/services/javax.annotation.processing.Processor</source>
+      <outputDirectory>META-INF</outputDirectory>
+    </file>
+  </files>    
 </assembly>

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.vertx.codegen.CodeGenProcessor


### PR DESCRIPTION
Some libraries running the annotation processors expect them to be declared a 'javax.annotation.processing.Processor' service. For example, Kotlin Annotation Processing Tool (http://blog.jetbrains.com/kotlin/2015/06/better-annotation-processing-supporting-stubs-in-kapt/).