### PR TITLE
Improve TypeInfo test to also test the model type info construction

### DIFF
--- a/src/main/java/io/vertx/core/streams/ReadStream.java
+++ b/src/main/java/io/vertx/core/streams/ReadStream.java
@@ -1,7 +1,10 @@
 package io.vertx.core.streams;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@VertxGen(concrete = false)
 public interface ReadStream<T> {
 }

--- a/src/test/java/io/vertx/test/codegen/TypeInfoTest.java
+++ b/src/test/java/io/vertx/test/codegen/TypeInfoTest.java
@@ -1,21 +1,43 @@
 package io.vertx.test.codegen;
 
 import io.vertx.codegen.ClassKind;
+import io.vertx.codegen.Helper;
 import io.vertx.codegen.TypeInfo;
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.TypeParamInfo;
+import io.vertx.codegen.testmodel.TestDataObject;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.codegen.testapi.GenericInterface;
-import io.vertx.test.codegen.testapi.InterfaceWithParameterizedDeclaredSupertype;
-import io.vertx.test.codegen.testapi.InterfaceWithParameterizedVariableSupertype;
+import io.vertx.test.codegen.testapi.streams.InterfaceExtentingReadStream;
+import io.vertx.test.codegen.testapi.streams.InterfaceSubtypingReadStream;
+import io.vertx.test.codegen.testapi.streams.ReadStreamWithParameterizedTypeArg;
+import io.vertx.test.codegen.testtype.ApiHolder;
+import io.vertx.test.codegen.testtype.ApiObject;
+import io.vertx.test.codegen.testtype.AsyncHolder;
+import io.vertx.test.codegen.testtype.BasicHolder;
+import io.vertx.test.codegen.testtype.CollectionHolder;
+import io.vertx.test.codegen.testtype.DataObjectHolder;
+import io.vertx.test.codegen.testtype.EnumHolder;
+import io.vertx.test.codegen.testtype.HandlerHolder;
+import io.vertx.test.codegen.testtype.JsonHolder;
+import io.vertx.test.codegen.testtype.OtherHolder;
+import io.vertx.test.codegen.testtype.StreamHolder;
+import io.vertx.test.codegen.testtype.ThrowableHolder;
+import io.vertx.test.codegen.testtype.TypeParamHolder;
+import io.vertx.test.codegen.testtype.VoidHolder;
 import org.junit.Test;
 
+import javax.lang.model.element.TypeElement;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 
@@ -24,110 +46,273 @@ import static org.junit.Assert.*;
  */
 public class TypeInfoTest {
 
+  private void doTest(Class<?> container, Consumer<Map<String, TypeInfo>> assertion) throws Exception {
+    Map<String, TypeInfo> reflectedMap = Stream.of(container.getDeclaredMethods()).filter(m -> Modifier.isPublic(m.getModifiers())).
+        collect(Collectors.toMap(Method::getName, m -> TypeInfo.create(m.getGenericReturnType())));
+    assertion.accept(reflectedMap);
+    Utils.assertProcess((proc, env) -> {
+      TypeInfo.Factory factory = new TypeInfo.Factory(proc.getElementUtils(), proc.getTypeUtils());
+      TypeElement modelMap = proc.getElementUtils().getTypeElement(container.getName());
+      Map<String, TypeInfo> collect = modelMap.getEnclosedElements().stream().
+          flatMap(Helper.FILTER_METHOD).
+          filter(elt -> elt.getModifiers().contains(javax.lang.model.element.Modifier.PUBLIC)).
+          collect(Collectors.toMap(m -> m.getSimpleName().toString(), m -> factory.create(m.getReturnType())));
+      assertion.accept(collect);
+    });
+  }
+
   @Test
   public void testVoid() throws Exception {
-    TypeInfo.Void info = (TypeInfo.Void) TypeInfo.create(void.class);
-    assertEquals("void", info.getName());
-    assertEquals("void", info.getSimpleName());
+    doTest(VoidHolder.class, map -> {
+      TypeInfo.Void voidType = (TypeInfo.Void) map.get("voidType");
+      assertEquals("void", voidType.getName());
+      assertEquals("void", voidType.getSimpleName());
+      assertEquals(ClassKind.OTHER, voidType.getKind());
+      assertClass(map.get("VoidType"), "java.lang.Void", ClassKind.VOID);
+    });
   }
 
   @Test
-  public void testPrimitive() throws Exception {
-    TypeInfo.Primitive info = (TypeInfo.Primitive) TypeInfo.create(int.class);
-    assertEquals("int", info.getName());
-    assertEquals("int", info.getSimpleName());
+  public void testApi() throws Exception {
+    doTest(ApiHolder.class, map -> {
+      TypeInfo.Class.Api api = assertApi(map.get("api"), ApiObject.class.getName());
+      assertEquals(ApiObject.class.getName(), api.getName());
+      TypeInfo.Parameterized apiParameterizedByClass = assertParameterized(map.get("apiParameterizedByClass"), GenericInterface.class.getName() + "<java.lang.String>", ClassKind.API);
+      assertClass(apiParameterizedByClass.getArg(0), "java.lang.String", ClassKind.STRING);
+      TypeInfo.Parameterized apiParameterizedByClassTypeParam = assertParameterized(map.get("apiParameterizedByClassTypeParam"), GenericInterface.class.getName() + "<ClassTypeParam>", ClassKind.API);
+      TypeParamInfo.Class classTypeParam = (TypeParamInfo.Class) assertTypeVariable(apiParameterizedByClassTypeParam.getArg(0), "ClassTypeParam").getParam();
+      assertEquals("ClassTypeParam", classTypeParam.getName());
+      TypeInfo.Parameterized apiParameterizedByMethodTypeParam = assertParameterized(map.get("apiParameterizedByMethodTypeParam"), GenericInterface.class.getName() + "<MethodTypeParam>", ClassKind.API);
+      TypeParamInfo.Method methodTypeParam = (TypeParamInfo.Method) assertTypeVariable(apiParameterizedByMethodTypeParam.getArg(0), "MethodTypeParam").getParam();
+      assertEquals("MethodTypeParam", methodTypeParam.getName());
+    });
   }
 
   @Test
-  public void testParameterizedWithClass() {
-    TypeInfo.Parameterized info = (TypeInfo.Parameterized) TypeInfo.create(InterfaceWithParameterizedDeclaredSupertype.class.getGenericInterfaces()[0]);
-    assertEquals("io.vertx.test.codegen.testapi.GenericInterface<java.lang.String>", info.getName());
-    assertEquals("GenericInterface<String>", info.getSimpleName());
+  public void testTypeParam() throws Exception {
+    doTest(TypeParamHolder.class, map -> {
+      TypeParamInfo.Class classTypeParam = (TypeParamInfo.Class) assertTypeVariable(map.get("classTypeParam"), "ClassTypeParam").getParam();
+      assertEquals("ClassTypeParam", classTypeParam.getName());
+      TypeParamInfo.Method methodTypeParam = (TypeParamInfo.Method) assertTypeVariable(map.get("methodTypeParam"), "MethodTypeParam").getParam();
+      assertEquals("MethodTypeParam", methodTypeParam.getName());
+    });
   }
 
   @Test
-  public void testParameterizedWithTypeVariable() {
-    TypeInfo.Parameterized info = (TypeInfo.Parameterized) TypeInfo.create(InterfaceWithParameterizedVariableSupertype.class.getGenericInterfaces()[0]);
-    assertEquals("io.vertx.test.codegen.testapi.GenericInterface<T>", info.getName());
-    assertEquals("GenericInterface<T>", info.getSimpleName());
+  public void testClass() throws Exception {
+    doTest(OtherHolder.class, map -> {
+      assertClass(map.get("classType"), "java.util.Locale", ClassKind.OTHER);
+      assertClass(map.get("interfaceType"), "java.lang.Runnable", ClassKind.OTHER);
+      assertClass(map.get("genericInterface"), "java.util.concurrent.Callable", ClassKind.OTHER);
+      assertClass(assertParameterized(map.get("interfaceParameterizedByInterface"), "java.util.concurrent.Callable<java.lang.Runnable>", ClassKind.OTHER).getArg(0), "java.lang.Runnable", ClassKind.OTHER);
+      assertClass(assertParameterized(map.get("interfaceParameterizedByClass"), "java.util.concurrent.Callable<java.util.Locale>", ClassKind.OTHER).getArg(0), "java.util.Locale", ClassKind.OTHER);
+      assertTypeVariable(assertParameterized(map.get("interfaceParameterizedByClassTypeParam"), "java.util.concurrent.Callable<ClassTypeParam>", ClassKind.OTHER).getArg(0), "ClassTypeParam");
+      assertTypeVariable(assertParameterized(map.get("interfaceParameterizedByMethodTypeParam"), "java.util.concurrent.Callable<MethodTypeParam>", ClassKind.OTHER).getArg(0), "MethodTypeParam");
+      assertClass(assertParameterized(map.get("classParameterizedByInterface"), "java.util.Vector<java.lang.Runnable>", ClassKind.OTHER).getArg(0), "java.lang.Runnable", ClassKind.OTHER);
+      assertClass(assertParameterized(map.get("classParameterizedByClass"), "java.util.Vector<java.util.Locale>", ClassKind.OTHER).getArg(0), "java.util.Locale", ClassKind.OTHER);
+      assertTypeVariable(assertParameterized(map.get("classParameterizedByClassTypeParam"), "java.util.Vector<ClassTypeParam>", ClassKind.OTHER).getArg(0), "ClassTypeParam");
+      assertTypeVariable(assertParameterized(map.get("classParameterizedByMethodTypeParam"), "java.util.Vector<MethodTypeParam>", ClassKind.OTHER).getArg(0), "MethodTypeParam");
+    });
   }
 
   @Test
-  public void testTypeVariable() throws Exception {
-    Method m = GenericInterface.class.getMethods()[0];
-    TypeInfo.Variable info = (TypeInfo.Variable) TypeInfo.create(m.getGenericReturnType());
-    assertEquals("T", info.getName());
-    assertEquals("T", info.getSimpleName());
+  public void testHandler() throws Exception {
+    doTest(HandlerHolder.class, map -> {
+      assertClass(assertHandler(map.get("handlerVoid"), "java.lang.Void"), "java.lang.Void", ClassKind.VOID);
+      assertClass(assertHandler(map.get("handlerString"), "java.lang.String"), "java.lang.String", ClassKind.STRING);
+      assertClass(assertParameterized(assertHandler(map.get("handlerListString"), "java.util.List<java.lang.String>"), "java.util.List<java.lang.String>", ClassKind.LIST).getArg(0), "java.lang.String", ClassKind.STRING);
+      assertApi(assertParameterized(assertHandler(map.get("handlerListApi"), "java.util.List<" + ApiObject.class.getName() + ">"), "java.util.List<" + ApiObject.class.getName() + ">", ClassKind.LIST).getArg(0), ApiObject.class.getName());
+      assertTypeVariable(assertParameterized(assertHandler(map.get("handlerParameterizedByClassTypeParam"), GenericInterface.class.getName() + "<ClassTypeParam>"), GenericInterface.class.getName() + "<ClassTypeParam>", ClassKind.API).getArg(0), "ClassTypeParam");
+      assertTypeVariable(assertParameterized(assertHandler(map.get("handlerParameterizedByMethodTypeParam"), GenericInterface.class.getName() + "<MethodTypeParam>"), GenericInterface.class.getName() + "<MethodTypeParam>", ClassKind.API).getArg(0), "MethodTypeParam");
+    });
   }
 
   @Test
-  public void testClass() {
-    TypeInfo.Class info = (TypeInfo.Class) TypeInfo.create(String.class);
-    assertEquals("java.lang.String", info.getName());
-    assertEquals("String", info.getSimpleName());
+  public void testAsync() throws Exception {
+    doTest(AsyncHolder.class, map -> {
+      assertClass(assertAsync(map.get("asyncVoid"), "java.lang.Void"), "java.lang.Void", ClassKind.VOID);
+      assertClass(assertAsync(map.get("asyncString"), "java.lang.String"), "java.lang.String", ClassKind.STRING);
+      assertClass(assertParameterized(assertAsync(map.get("asyncListString"), "java.util.List<java.lang.String>"), "java.util.List<java.lang.String>", ClassKind.LIST).getArg(0), "java.lang.String", ClassKind.STRING);
+      assertApi(assertParameterized(assertAsync(map.get("asyncListApi"), "java.util.List<" + ApiObject.class.getName() + ">"), "java.util.List<" + ApiObject.class.getName() + ">", ClassKind.LIST).getArg(0), ApiObject.class.getName());
+      assertTypeVariable(assertParameterized(assertAsync(map.get("asyncParameterizedByClassTypeParam"), GenericInterface.class.getName() + "<ClassTypeParam>"), GenericInterface.class.getName() + "<ClassTypeParam>", ClassKind.API).getArg(0), "ClassTypeParam");
+      assertTypeVariable(assertParameterized(assertAsync(map.get("asyncParameterizedByMethodTypeParam"), GenericInterface.class.getName() + "<MethodTypeParam>"), GenericInterface.class.getName() + "<MethodTypeParam>", ClassKind.API).getArg(0), "MethodTypeParam");
+    });
   }
 
   @Test
-  public void testInterface() {
-    TypeInfo.Class info = (TypeInfo.Class) TypeInfo.create(Runnable.class);
-    assertEquals("java.lang.Runnable", info.getName());
-    assertEquals("Runnable", info.getSimpleName());
-  }
-
-  // TypeKind testing
-
-  @Test
-  public void testComposeKinds() {
-    abstract class Container implements AsyncResult<List<String>>  {}
-    TypeInfo.Parameterized info = (TypeInfo.Parameterized) TypeInfo.create(Container.class.getGenericInterfaces()[0]);
-    assertEquals(ClassKind.ASYNC_RESULT, info.getKind());
-    TypeInfo.Parameterized a = (TypeInfo.Parameterized) info.getArgs().get(0);
-    assertEquals(ClassKind.LIST, a.getKind());
-    TypeInfo.Class b = (TypeInfo.Class) a.getArgs().get(0);
-    assertEquals(ClassKind.STRING, b.getKind());
+  public void testDataObject() throws Exception {
+    doTest(DataObjectHolder.class, map -> {
+      assertClass(map.get("dataObject"), TestDataObject.class.getName(), ClassKind.DATA_OBJECT);
+    });
   }
 
   @Test
-  public void testPrimitiveKind() {
-
-    @VertxGen class ApiObject {}
-    @DataObject
-    class DataObjectObject {}
-    class Other {}
-
-    assertEquals(ClassKind.OTHER, TypeInfo.create(Other.class).getKind());
-    assertEquals(ClassKind.DATA_OBJECT, TypeInfo.create(DataObjectObject.class).getKind());
-    assertEquals(ClassKind.API, TypeInfo.create(ApiObject.class).getKind());
-    assertEquals(ClassKind.HANDLER, TypeInfo.create(Handler.class).getKind());
-    assertEquals(ClassKind.ASYNC_RESULT, TypeInfo.create(AsyncResult.class).getKind());
-    assertEquals(ClassKind.VOID, TypeInfo.create(Void.class).getKind());
-    assertEquals(ClassKind.JSON_ARRAY, TypeInfo.create(JsonArray.class).getKind());
-    assertEquals(ClassKind.JSON_OBJECT, TypeInfo.create(JsonObject.class).getKind());
-    assertEquals(ClassKind.OBJECT, TypeInfo.create(Object.class).getKind());
-    assertEquals(ClassKind.STRING, TypeInfo.create(String.class).getKind());
-    assertEquals(ClassKind.LIST, TypeInfo.create(List.class).getKind());
-    assertEquals(ClassKind.SET, TypeInfo.create(Set.class).getKind());
-    assertEquals(ClassKind.THROWABLE, TypeInfo.create(Throwable.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(boolean.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(int.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(long.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(double.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(float.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(byte.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(short.class).getKind());
-    assertEquals(ClassKind.PRIMITIVE, TypeInfo.create(char.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Boolean.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Integer.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Long.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Double.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Float.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Byte.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Short.class).getKind());
-    assertEquals(ClassKind.BOXED_PRIMITIVE, TypeInfo.create(Character.class).getKind());
+  public void testJson() throws Exception {
+    doTest(JsonHolder.class, map -> {
+      assertClass(map.get("jsonObject"), JsonObject.class.getName(), ClassKind.JSON_OBJECT);
+      assertClass(map.get("jsonArray"), JsonArray.class.getName(), ClassKind.JSON_ARRAY);
+    });
   }
 
   @Test
-  public void testBoxedPrimitiveKind() {
+  public void testThrowable() throws Exception {
+    doTest(ThrowableHolder.class, map -> {
+      assertClass(map.get("throwable"), "java.lang.Throwable", ClassKind.THROWABLE);
+    });
+  }
+
+  @Test
+  public void testBasic() throws Exception {
+    doTest(BasicHolder.class, map -> {
+      assertPrimitive(map.get("booleanType"), "boolean");
+      assertPrimitive(map.get("byteType"), "byte");
+      assertPrimitive(map.get("shortType"), "short");
+      assertPrimitive(map.get("intType"), "int");
+      assertPrimitive(map.get("longType"), "long");
+      assertPrimitive(map.get("floatType"), "float");
+      assertPrimitive(map.get("doubleType"), "double");
+      assertPrimitive(map.get("charType"), "char");
+      assertClass(map.get("BooleanType"), "java.lang.Boolean", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("ShortType"), "java.lang.Short", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("IntegerType"), "java.lang.Integer", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("LongType"), "java.lang.Long", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("FloatType"), "java.lang.Float", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("DoubleType"), "java.lang.Double", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("CharacterType"), "java.lang.Character", ClassKind.BOXED_PRIMITIVE);
+      assertClass(map.get("StringType"), "java.lang.String", ClassKind.STRING);
+    });
+  }
+
+  private TypeInfo.Primitive assertPrimitive(TypeInfo type, String expectedName) {
+    assertEquals(TypeInfo.Primitive.class, type.getClass());
+    TypeInfo.Primitive primitiveType = (TypeInfo.Primitive) type;
+    assertEquals(ClassKind.PRIMITIVE, primitiveType.getKind());
+    assertEquals(expectedName, primitiveType.getName());
+    return primitiveType;
+  }
+
+  private TypeInfo.Variable assertTypeVariable(TypeInfo type, String expectedName) {
+    assertEquals(TypeInfo.Variable.class, type.getClass());
+    TypeInfo.Variable classType = (TypeInfo.Variable) type;
+    assertEquals(ClassKind.OBJECT, classType.getKind());
+    assertEquals(expectedName, classType.getName());
+    return classType;
+  }
+
+  private TypeInfo.Class assertClass(TypeInfo type, String expectedName, ClassKind expectedKind) {
+    assertEquals(TypeInfo.Class.class, type.getClass());
+    TypeInfo.Class classType = (TypeInfo.Class) type;
+    assertEquals(expectedKind, classType.getKind());
+    assertEquals(expectedName, classType.getName());
+    return classType;
+  }
+
+  private TypeInfo.Class.Api assertApi(TypeInfo type, String expectedName) {
+    assertEquals(TypeInfo.Class.Api.class, type.getClass());
+    TypeInfo.Class.Api apiType = (TypeInfo.Class.Api) type;
+    assertEquals(ClassKind.API, apiType.getKind());
+    assertEquals(expectedName, apiType.getName());
+    return apiType;
+  }
+
+  private TypeInfo.Parameterized assertParameterized(TypeInfo type, String expectedName, ClassKind expectedKind) {
+    assertEquals(TypeInfo.Parameterized.class, type.getClass());
+    TypeInfo.Parameterized parameterizedType = (TypeInfo.Parameterized) type;
+    assertEquals(expectedKind, parameterizedType.getKind());
+    assertEquals(expectedName, parameterizedType.getName());
+    return parameterizedType;
+  }
+
+  private TypeInfo assertAsync(TypeInfo type, String name) {
+    String asyncName = "io.vertx.core.AsyncResult<" + name + ">";
+    TypeInfo.Parameterized handlerType = assertParameterized(assertHandler(type, asyncName), asyncName, ClassKind.ASYNC_RESULT);
+    TypeInfo.Parameterized resultType = assertParameterized(handlerType, asyncName, ClassKind.ASYNC_RESULT);
+    return resultType.getArg(0);
+  }
+
+  private TypeInfo assertHandler(TypeInfo type, String name) {
+    String handlerName = "io.vertx.core.Handler<" + name + ">";
+    TypeInfo.Parameterized handlerType = assertParameterized(type, handlerName, ClassKind.HANDLER);
+    return handlerType.getArg(0);
+  }
+
+  @Test
+  public void testCollection() throws Exception {
+    doTest(CollectionHolder.class, map -> {
+      String[] colTypes = { "list", "set", "map" };
+      ClassKind[] colKinds = { ClassKind.LIST, ClassKind.SET, ClassKind.MAP };
+      List<List<String>> colTypeParams = Arrays.asList(
+          Collections.singletonList("E"),
+          Collections.singletonList("E"),
+          Arrays.asList("K", "V"));
+      int[] typeParamIndexes = {0, 0, 1};
+      for (int idx = 0;idx < colKinds.length;idx++) {
+        String colType = colTypes[idx];
+        ClassKind colKind = colKinds[idx];
+        TypeInfo.Class col = (TypeInfo.Class) map.get(colType);
+        int typeParamIndex = typeParamIndexes[idx];
+        assertEquals(colKind, col.getKind());
+        assertEquals(TypeInfo.Class.class, col.getClass());
+        assertEquals(colTypeParams.get(idx), col.getParams().stream().map(TypeParamInfo::getName).collect(Collectors.toList()));
+        TypeInfo.Parameterized ofString = (TypeInfo.Parameterized) map.get(colType + "OfString");
+        assertEquals(colKind, ofString.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofString.getClass());
+        assertEquals(col, ofString.getRaw());
+        assertEquals(map.get("String"), ofString.getArg(typeParamIndex));
+        TypeInfo.Parameterized ofClassTypeParam = (TypeInfo.Parameterized) map.get(colType + "OfClassTypeParam");
+        assertEquals(colKind, ofClassTypeParam.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofClassTypeParam.getClass());
+        assertEquals(col, ofClassTypeParam.getRaw());
+        assertEquals(map.get("ClassTypeParam"), ofClassTypeParam.getArg(typeParamIndex));
+        TypeInfo.Parameterized ofMethodTypeParam = (TypeInfo.Parameterized) map.get(colType + "OfMethodTypeParam");
+        assertEquals(colKind, ofMethodTypeParam.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofMethodTypeParam.getClass());
+        assertEquals(col, ofMethodTypeParam.getRaw());
+        assertEquals(1 + typeParamIndex, ofMethodTypeParam.getArgs().size());
+        TypeParamInfo.Method methodTypeParam = (TypeParamInfo.Method) ((TypeInfo.Variable) ofMethodTypeParam.getArg(typeParamIndex)).getParam();
+        assertEquals("MethodTypeParam", methodTypeParam.getName());
+        TypeInfo.Parameterized ofDataObject = (TypeInfo.Parameterized) map.get(colType + "OfDataObject");
+        assertEquals(colKind, ofDataObject.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofDataObject.getClass());
+        assertEquals(map.get("DataObject"), ofDataObject.getArg(typeParamIndex));
+        TypeInfo.Parameterized ofJsonObject = (TypeInfo.Parameterized) map.get(colType + "OfJsonObject");
+        assertEquals(colKind, ofJsonObject.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofJsonObject.getClass());
+        assertEquals(map.get("JsonObject"), ofJsonObject.getArg(typeParamIndex));
+        TypeInfo.Parameterized ofJsonArray = (TypeInfo.Parameterized) map.get(colType + "OfJsonArray");
+        assertEquals(colKind, ofJsonArray.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofJsonArray.getClass());
+        assertEquals(map.get("JsonArray"), ofJsonArray.getArg(typeParamIndex));
+      }
+    });
+  }
+
+  @Test
+  public void testStream() throws Exception {
+    doTest(StreamHolder.class, map -> {
+      TypeInfo.Class.Api readStreamOfString = assertApi(assertParameterized(map.get("readStreamOfString"), "io.vertx.core.streams.ReadStream<java.lang.String>", ClassKind.API).getRaw(), "io.vertx.core.streams.ReadStream");
+      assertTypeVariable(readStreamOfString.getReadStreamArg(), "T");
+      TypeInfo.Class.Api extendsReadStreamWithClassArg = assertApi(map.get("extendsReadStreamWithClassArg"), InterfaceExtentingReadStream.class.getName());
+      assertClass(extendsReadStreamWithClassArg.getReadStreamArg(), "java.lang.String", ClassKind.STRING);
+      TypeInfo.Class.Api extendsGenericReadStreamSubTypeWithClassArg = assertApi(map.get("extendsGenericReadStreamSubTypeWithClassArg"), InterfaceSubtypingReadStream.class.getName());
+      assertClass(extendsGenericReadStreamSubTypeWithClassArg.getReadStreamArg(), "java.lang.String", ClassKind.STRING);
+      TypeInfo.Class.Api genericReadStreamSubTypeWithClassTypeParamArg = assertApi(assertParameterized(map.get("genericReadStreamSubTypeWithClassTypeParamArg"), ReadStreamWithParameterizedTypeArg.class.getName() + "<ClassTypeParam>", ClassKind.API).getRaw(), "io.vertx.test.codegen.testapi.streams.ReadStreamWithParameterizedTypeArg");
+      // Cannot assert the correct value for now becasue Java does not provide enough info
+    });
+  }
+
+  @Test
+  public void testEnum() throws Exception {
+    doTest(EnumHolder.class, map -> {
+      TypeInfo.Class.Enum apiEnum = (TypeInfo.Class.Enum) map.get("apiEnum");
+      assertEquals(ClassKind.ENUM, apiEnum.getKind());
+      assertEquals(Arrays.asList("RED", "GREEN", "BLUE"), apiEnum.getValues());
+      assertTrue(apiEnum.isGen());
+      TypeInfo.Class.Enum otherEnum = (TypeInfo.Class.Enum) map.get("otherEnum");
+      assertEquals(ClassKind.ENUM, otherEnum.getKind());
+      assertEquals(Arrays.asList("NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"), otherEnum.getValues());
+      assertFalse(otherEnum.isGen());
+    });
   }
 
   @Test

--- a/src/test/java/io/vertx/test/codegen/TypeInfoTest.java
+++ b/src/test/java/io/vertx/test/codegen/TypeInfoTest.java
@@ -283,6 +283,10 @@ public class TypeInfoTest {
         assertEquals(colKind, ofJsonArray.getKind());
         assertEquals(TypeInfo.Parameterized.class, ofJsonArray.getClass());
         assertEquals(map.get("JsonArray"), ofJsonArray.getArg(typeParamIndex));
+        TypeInfo.Parameterized ofEnum = (TypeInfo.Parameterized) map.get(colType + "OfEnum");
+        assertEquals(colKind, ofEnum.getKind());
+        assertEquals(TypeInfo.Parameterized.class, ofEnum.getClass());
+        assertEquals(map.get("Enum"), ofEnum.getArg(typeParamIndex));
       }
     });
   }

--- a/src/test/java/io/vertx/test/codegen/testtype/ApiHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/ApiHolder.java
@@ -1,0 +1,16 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.test.codegen.testapi.GenericInterface;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface ApiHolder<ClassTypeParam> {
+
+
+  ApiObject api();
+  GenericInterface<String> apiParameterizedByClass();
+  GenericInterface<ClassTypeParam> apiParameterizedByClassTypeParam();
+  <MethodTypeParam> GenericInterface<MethodTypeParam> apiParameterizedByMethodTypeParam();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/ApiObject.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/ApiObject.java
@@ -1,10 +1,10 @@
-package io.vertx.core.streams;
+package io.vertx.test.codegen.testtype;
 
 import io.vertx.codegen.annotations.VertxGen;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@VertxGen(concrete = false)
-public interface WriteStream<T> {
+@VertxGen
+public interface ApiObject {
 }

--- a/src/test/java/io/vertx/test/codegen/testtype/AsyncHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/AsyncHolder.java
@@ -1,0 +1,21 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.test.codegen.testapi.GenericInterface;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface AsyncHolder<ClassTypeParam> {
+
+  Handler<AsyncResult<Void>> asyncVoid();
+  Handler<AsyncResult<String>> asyncString();
+  Handler<AsyncResult<List<String>>> asyncListString();
+  Handler<AsyncResult<List<ApiObject>>> asyncListApi();
+  Handler<AsyncResult<GenericInterface<ClassTypeParam>>> asyncParameterizedByClassTypeParam();
+  <MethodTypeParam> Handler<AsyncResult<GenericInterface<MethodTypeParam>>> asyncParameterizedByMethodTypeParam();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/BasicHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/BasicHolder.java
@@ -1,0 +1,28 @@
+package io.vertx.test.codegen.testtype;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface BasicHolder {
+
+  boolean booleanType();
+  byte byteType();
+  short shortType();
+  int intType();
+  long longType();
+  float floatType();
+  double doubleType();
+  char charType();
+
+  Boolean BooleanType();
+  Byte ByteType();
+  Short ShortType();
+  Integer IntegerType();
+  Long LongType();
+  Float FloatType();
+  Double DoubleType();
+  Character CharacterType();
+
+  String StringType();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/CollectionHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/CollectionHolder.java
@@ -3,6 +3,7 @@ package io.vertx.test.codegen.testtype;
 import io.vertx.codegen.testmodel.TestDataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.test.codegen.testenum.ValidEnum;
 
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ public interface CollectionHolder<ClassTypeParam> {
   TestDataObject DataObject();
   JsonObject JsonObject();
   JsonArray JsonArray();
+  ValidEnum Enum();
 
   List list();
   List<String> listOfString();
@@ -26,6 +28,7 @@ public interface CollectionHolder<ClassTypeParam> {
   List<TestDataObject> listOfDataObject();
   List<JsonObject> listOfJsonObject();
   List<JsonArray> listOfJsonArray();
+  List<ValidEnum> listOfEnum();
 
   Set set();
   Set<String> setOfString();
@@ -34,6 +37,7 @@ public interface CollectionHolder<ClassTypeParam> {
   Set<TestDataObject> setOfDataObject();
   Set<JsonObject> setOfJsonObject();
   Set<JsonArray> setOfJsonArray();
+  Set<ValidEnum> setOfEnum();
 
   Map map();
   Map<String, String> mapOfString();
@@ -42,4 +46,5 @@ public interface CollectionHolder<ClassTypeParam> {
   Map<String, TestDataObject> mapOfDataObject();
   Map<String, JsonObject> mapOfJsonObject();
   Map<String, JsonArray> mapOfJsonArray();
+  Map<String, ValidEnum> mapOfEnum();
 }

--- a/src/test/java/io/vertx/test/codegen/testtype/CollectionHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/CollectionHolder.java
@@ -1,0 +1,45 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.codegen.testmodel.TestDataObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface CollectionHolder<ClassTypeParam> {
+
+  String String();
+  ClassTypeParam ClassTypeParam();
+  TestDataObject DataObject();
+  JsonObject JsonObject();
+  JsonArray JsonArray();
+
+  List list();
+  List<String> listOfString();
+  List<ClassTypeParam> listOfClassTypeParam();
+  <MethodTypeParam> List<MethodTypeParam> listOfMethodTypeParam();
+  List<TestDataObject> listOfDataObject();
+  List<JsonObject> listOfJsonObject();
+  List<JsonArray> listOfJsonArray();
+
+  Set set();
+  Set<String> setOfString();
+  Set<ClassTypeParam> setOfClassTypeParam();
+  <MethodTypeParam> Set<MethodTypeParam> setOfMethodTypeParam();
+  Set<TestDataObject> setOfDataObject();
+  Set<JsonObject> setOfJsonObject();
+  Set<JsonArray> setOfJsonArray();
+
+  Map map();
+  Map<String, String> mapOfString();
+  Map<String, ClassTypeParam> mapOfClassTypeParam();
+  <MethodTypeParam> Map<String, MethodTypeParam> mapOfMethodTypeParam();
+  Map<String, TestDataObject> mapOfDataObject();
+  Map<String, JsonObject> mapOfJsonObject();
+  Map<String, JsonArray> mapOfJsonArray();
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/DataObjectHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/DataObjectHolder.java
@@ -1,0 +1,12 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.codegen.testmodel.TestDataObject;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface DataObjectHolder {
+
+  TestDataObject dataObject();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/EnumHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/EnumHolder.java
@@ -1,0 +1,16 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.test.codegen.testenum.ValidEnum;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface EnumHolder {
+
+
+  ValidEnum apiEnum();
+  TimeUnit otherEnum();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/HandlerHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/HandlerHolder.java
@@ -1,0 +1,20 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.core.Handler;
+import io.vertx.test.codegen.testapi.GenericInterface;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface HandlerHolder<ClassTypeParam> {
+
+  Handler<Void> handlerVoid();
+  Handler<String> handlerString();
+  Handler<List<String>> handlerListString();
+  Handler<List<ApiObject>> handlerListApi();
+  Handler<GenericInterface<ClassTypeParam>> handlerParameterizedByClassTypeParam();
+  <MethodTypeParam> Handler<GenericInterface<MethodTypeParam>> handlerParameterizedByMethodTypeParam();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/JsonHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/JsonHolder.java
@@ -1,0 +1,14 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface JsonHolder {
+
+  JsonObject jsonObject();
+  JsonArray jsonArray();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/OtherHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/OtherHolder.java
@@ -1,0 +1,25 @@
+package io.vertx.test.codegen.testtype;
+
+import java.util.Locale;
+import java.util.Vector;
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface OtherHolder<ClassTypeParam> {
+
+  Locale classType();
+  Runnable interfaceType();
+  Callable genericInterface();
+  Callable<Runnable> interfaceParameterizedByInterface();
+  Callable<Locale> interfaceParameterizedByClass();
+  Callable<ClassTypeParam> interfaceParameterizedByClassTypeParam();
+  <MethodTypeParam> Callable<MethodTypeParam> interfaceParameterizedByMethodTypeParam();
+  Vector genericClass();
+  Vector<Runnable> classParameterizedByInterface();
+  Vector<Locale> classParameterizedByClass();
+  Vector<ClassTypeParam> classParameterizedByClassTypeParam();
+  <MethodTypeParam> Vector<MethodTypeParam> classParameterizedByMethodTypeParam();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/StreamHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/StreamHolder.java
@@ -1,0 +1,18 @@
+package io.vertx.test.codegen.testtype;
+
+import io.vertx.core.streams.ReadStream;
+import io.vertx.test.codegen.testapi.streams.InterfaceExtentingReadStream;
+import io.vertx.test.codegen.testapi.streams.InterfaceSubtypingReadStream;
+import io.vertx.test.codegen.testapi.streams.ReadStreamWithParameterizedTypeArg;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface StreamHolder<ClassTypeParam> {
+
+  ReadStream<String> readStreamOfString();
+  InterfaceExtentingReadStream extendsReadStreamWithClassArg();
+  InterfaceSubtypingReadStream  extendsGenericReadStreamSubTypeWithClassArg();
+  ReadStreamWithParameterizedTypeArg<ClassTypeParam> genericReadStreamSubTypeWithClassTypeParamArg();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/ThrowableHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/ThrowableHolder.java
@@ -1,0 +1,10 @@
+package io.vertx.test.codegen.testtype;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface ThrowableHolder {
+
+  Throwable throwable();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/TypeParamHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/TypeParamHolder.java
@@ -1,0 +1,11 @@
+package io.vertx.test.codegen.testtype;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface TypeParamHolder<ClassTypeParam> {
+
+  ClassTypeParam classTypeParam();
+  <MethodTypeParam> MethodTypeParam methodTypeParam();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testtype/VoidHolder.java
+++ b/src/test/java/io/vertx/test/codegen/testtype/VoidHolder.java
@@ -1,0 +1,11 @@
+package io.vertx.test.codegen.testtype;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface VoidHolder {
+
+  void voidType();
+  Void VoidType();
+
+}


### PR DESCRIPTION
A set of TypeInfo improvements, mostly missing tests and the TypeInfo based on java.lang.reflect was missing some handling.