### PR TITLE
Added support for supertypes with toJson() method

### DIFF
--- a/src/main/java/io/vertx/codegen/ProxyModel.java
+++ b/src/main/java/io/vertx/codegen/ProxyModel.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -71,7 +72,9 @@ public class ProxyModel extends ClassModel {
     // We also allow data object as parameter types if they have a 'public JsonObject toJson()' method
     if (typeInfo.getKind() == ClassKind.DATA_OBJECT) {
       if (type instanceof DeclaredType) {
-        List<TypeInfo> list = ((DeclaredType) type).asElement().getEnclosedElements().stream()
+        List<DeclaredType> directSupertypes = (List<DeclaredType>) this.typeUtils.directSupertypes(type);
+        List<Element> superTypeElements = directSupertypes.stream().map(superType -> superType.asElement()).flatMap(element -> element.getEnclosedElements().stream()).collect(Collectors.toList());
+        List<TypeInfo> list = Stream.concat(((DeclaredType) type).asElement().getEnclosedElements().stream(),superTypeElements.stream())
           .filter(e -> e.getKind() == ElementKind.METHOD)
           .map(e -> (ExecutableElement) e)
           .filter(e -> e.getParameters().size() == 0 && e.getSimpleName().toString().equals("toJson"))

--- a/src/test/java/io/vertx/test/codegen/ProxyTest.java
+++ b/src/test/java/io/vertx/test/codegen/ProxyTest.java
@@ -132,7 +132,7 @@ public class ProxyTest {
     assertEquals(ValidProxy.class.getName(), model.getIfaceFQCN());
     assertEquals(ValidProxy.class.getSimpleName(), model.getIfaceSimpleName());
     assertTrue(model.getSuperTypes().isEmpty());
-    assertEquals(45, model.getMethods().size());
+    assertEquals(46, model.getMethods().size());
 
     // Not going to check all the types are correct as this is already tested in the VertxGen tests
     // but we do want to check the proxyIgnore flag is correctly set

--- a/src/test/java/io/vertx/test/codegen/proxytestapi/ProxyDataObjectParent.java
+++ b/src/test/java/io/vertx/test/codegen/proxytestapi/ProxyDataObjectParent.java
@@ -1,0 +1,13 @@
+package io.vertx.test.codegen.proxytestapi;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Created by Erwin on 25/03/16.
+ */
+public abstract class ProxyDataObjectParent {
+
+    public JsonObject toJson() {
+        return new JsonObject();
+    }
+}

--- a/src/test/java/io/vertx/test/codegen/proxytestapi/ProxyDataObjectWithParent.java
+++ b/src/test/java/io/vertx/test/codegen/proxytestapi/ProxyDataObjectWithParent.java
@@ -1,0 +1,19 @@
+package io.vertx.test.codegen.proxytestapi;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Created by Erwin on 25/03/16.
+ */
+@DataObject
+public class ProxyDataObjectWithParent extends ProxyDataObjectParent {
+
+    public ProxyDataObjectWithParent() {
+    }
+
+    public ProxyDataObjectWithParent(JsonObject json) {
+    }
+
+
+}

--- a/src/test/java/io/vertx/test/codegen/proxytestapi/ValidProxy.java
+++ b/src/test/java/io/vertx/test/codegen/proxytestapi/ValidProxy.java
@@ -35,6 +35,9 @@ public interface ValidProxy {
 
   void dataObjectType(ProxyDataObject dataObject);
 
+  void dataObjectWithParentType(ProxyDataObjectWithParent dataObject);
+
+
   void handler0(Handler<AsyncResult<String>> stringHandler);
   void handler1(Handler<AsyncResult<Byte>> byteHandler);
   void handler2(Handler<AsyncResult<Short>> shortHandler);


### PR DESCRIPTION
This addition makes it possible to put the toJson method in the (abstract) parent of a DataObject.