### PR TITLE
add stable sorting by simple name for incremental processing

### DIFF
--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -210,6 +210,9 @@ public class CodeGenProcessor extends AbstractProcessor {
         File file = generated.file;
         Helper.ensureParentDir(file);
         try (FileWriter fileWriter = new FileWriter(file)) {
+          Collections.sort(generated, (o1, o2) ->
+                  o1.model.getElement().getSimpleName().toString().compareTo(
+                  o2.model.getElement().getSimpleName().toString()));
           for (int i = 0; i < generated.size(); i++) {
             ModelProcessing processing = generated.get(i);
             Map<String, Object> vars = new HashMap<>();


### PR DESCRIPTION
I found that when running the asciidoc generation on vertx-core the dataobjects.adoc and enums.adoc didn't have a stable sorting - at least they created on my PC a different sorting than the one in the repository. 

This PR suggests a sorting by SimpleName as I think it would be appropriate for cli-for-java.adoc, dataobjects.adoc, and enums.adoc in the context of vertx-core. 

When this PR is accepted, the documents in vertx-core should be re-created.