### PR TITLE
Fix for #81

### DIFF
--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -494,6 +494,9 @@ public class ClassModel implements Model {
         ifaceFQCN = elem.asType().toString();
         ifaceSimpleName = elem.getSimpleName().toString();
         ifacePackageName = elementUtils.getPackageOf(elem).toString();
+        if (ifacePackageName.startsWith("package ")) {
+          ifacePackageName = ifacePackageName.substring(8);
+        }
         ifaceComment = elementUtils.getDocComment(elem);
         doc = docFactory.createDoc(elem);
         concrete = elem.getAnnotation(VertxGen.class) == null || elem.getAnnotation(VertxGen.class).concrete();


### PR DESCRIPTION
As Eclipse JDT `PackageElement` emits "package XXX" instead of just "XXX", add a simple check and fix to make the codegen work with Eclipse compiler.

Manually validated the change locally, and generated code is correct.