### PR TITLE
RefedInterface1Impl.equals is now null safe

### DIFF
--- a/src/tck/java/io/vertx/codegen/testmodel/RefedInterface1Impl.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/RefedInterface1Impl.java
@@ -20,6 +20,8 @@ public class RefedInterface1Impl implements RefedInterface1 {
 
   @Override
   public boolean equals(Object obj) {
+    if (!(obj instanceof RefedInterface1Impl))
+      return false;
     return ((RefedInterface1Impl) obj).str.equals(str);
   }
 


### PR DESCRIPTION
I need RefedInterface1Impl.equals to be null safe for a few unit-tests for vertx-scala-lang.