### PR TITLE
DataObject.class appears twice in getSupportedAnnotationTypes

### DIFF
--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -61,7 +61,6 @@ public class CodeGenProcessor extends AbstractProcessor {
         VertxGen.class,
         ProxyGen.class,
         DataObject.class,
-        DataObject.class,
         ModuleGen.class
     ).stream().map(Class::getName).collect(Collectors.toSet());
   }


### PR DESCRIPTION
Remove duplicate DataObject.class