### PR TITLE
Fixed casting errors in DataObjectTCK

### DIFF
--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
@@ -64,9 +64,9 @@ public class DataObjectWithLists {
     floatValues = fromArray(json, "floatValues", o -> Float.parseFloat(o.toString()));
     doubleValues = fromArray(json, "doubleValues");
     stringValues = fromArray(json, "stringValues");
-    jsonObjectValues = fromArray(json, "jsonObjectValues", o -> new JsonObject((Map<String, Object>) o));
-    jsonArrayValues = fromArray(json, "jsonArrayValues", o -> new JsonArray((List) o));
-    dataObjectValues = fromArray(json, "dataObjectValues", o -> new TestDataObject(new JsonObject((Map<String, Object>) o)));
+    jsonObjectValues = fromArray(json, "jsonObjectValues", o -> (JsonObject) o);
+    jsonArrayValues = fromArray(json, "jsonArrayValues", o -> (JsonArray) o);
+    dataObjectValues = fromArray(json, "dataObjectValues", o -> new TestDataObject((JsonObject) o));
     enumValues = fromArray(json, "enumValues", o -> TestEnum.valueOf(o.toString()));
     genEnumValues = fromArray(json, "genEnumValues", o -> TestGenEnum.valueOf(o.toString()));
   }

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
@@ -71,9 +71,9 @@ public class DataObjectWithMaps {
     floatValues = fromObject(json, "floatValues", o -> Float.parseFloat(o.toString()));
     doubleValues = fromObject(json, "doubleValues");
     stringValues = fromObject(json, "stringValues");
-    jsonObjectValues = fromObject(json, "jsonObjectValues", o -> new JsonObject((Map<String, Object>) o));
-    jsonArrayValues = fromObject(json, "jsonArrayValues", o -> new JsonArray((List) o));
-    dataObjectValues = fromObject(json, "dataObjectValues", o -> new TestDataObject(new JsonObject((Map<String, Object>) o)));
+    jsonObjectValues = fromObject(json, "jsonObjectValues", o -> (JsonObject) o);
+    jsonArrayValues = fromObject(json, "jsonArrayValues", o -> (JsonArray) o);
+    dataObjectValues = fromObject(json, "dataObjectValues", o -> new TestDataObject((JsonObject) o));
     enumValues = fromObject(json, "enumValues", o -> TestEnum.valueOf(o.toString()));
     genEnumValues = fromObject(json, "genEnumValues", o -> TestGenEnum.valueOf(o.toString()));
   }


### PR DESCRIPTION
DataObjectWithLists and DataObjectWithMaps incorrectly tried to cast some JsonObjects to Map and JsonArrays to List.