### PR TITLE
Generate wildcard generic types using static annotation definition

### DIFF
--- a/src/main/java/io/vertx/codegen/GenException.java
+++ b/src/main/java/io/vertx/codegen/GenException.java
@@ -16,6 +16,12 @@ public class GenException extends RuntimeException {
     this.msg = msg;
   }
 
+  public GenException(Element element, String msg, Throwable cause) {
+    super(msg, cause);
+    this.element = element;
+    this.msg = msg;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/src/main/java/io/vertx/codegen/annotations/GenTypeParams.java
+++ b/src/main/java/io/vertx/codegen/annotations/GenTypeParams.java
@@ -1,0 +1,35 @@
+package io.vertx.codegen.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares mapping of generic type parameters to generated types.
+ * This can be used to remove wildcards in generated code but leave them in Java.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GenTypeParams {
+  
+  Param[] value();
+  
+  /**
+   * Declares mapping of generic type parameters to generated types.
+   * This can be used to remove wildcards in generated code but leave them in Java.
+   */
+  public @interface Param {
+
+    /**
+     * name of Java generic parameter that should be discarded, for example 'T'
+     */
+    String name();
+    /**
+     * class that be used for code generation instead 
+     */
+    Class generated();
+    
+  }
+  
+}

--- a/src/test/java/io/vertx/test/codegen/ClassTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassTest.java
@@ -168,6 +168,7 @@ import io.vertx.test.codegen.testapi.SameSignatureMethod2;
 import io.vertx.test.codegen.testapi.VertxGenClass1;
 import io.vertx.test.codegen.testapi.VertxGenClass2;
 import io.vertx.test.codegen.testapi.VertxGenInterface;
+import io.vertx.test.codegen.testapi.MethodWithDefinedApiWildcardTypeArg;
 import io.vertx.test.codegen.testapi.fluent.AbstractInterfaceWithFluentMethods;
 import io.vertx.test.codegen.testapi.fluent.ConcreteInterfaceWithFluentMethods;
 import io.vertx.test.codegen.testapi.fluent.FluentMethodOverrideWithSuperType;
@@ -203,7 +204,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
-
+ 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -412,6 +413,11 @@ public class ClassTest extends ClassTestBase {
     assertGenInvalid(MethodWithInvalidWildcardTypeArg.class);
   }
 
+  @Test
+  public void testValidWildcardTypeArg() throws Exception {
+    new Generator().generateClass(MethodWithDefinedApiWildcardTypeArg.class);
+  }
+  
   // Test valid stuff
   // ----------------
 

--- a/src/test/java/io/vertx/test/codegen/testapi/MethodWithDefinedApiWildcardTypeArg.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/MethodWithDefinedApiWildcardTypeArg.java
@@ -1,0 +1,21 @@
+package io.vertx.test.codegen.testapi;
+
+import java.util.List;
+
+import io.vertx.codegen.annotations.GenTypeParams;
+import io.vertx.codegen.annotations.GenTypeParams.Param;
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+@VertxGen
+public interface MethodWithDefinedApiWildcardTypeArg {
+
+  @GenTypeParams(@Param(name="GENERIC_INTERACE", generated=GenericInterface.class))
+  <GENERIC_INTERACE extends GenericInterface<?>> void fooApi(GENERIC_INTERACE generic);
+  
+  @GenTypeParams(@Param(name="ANY_LIST", generated=List.class))
+  <ANY_LIST extends List<?>> void fooList(ANY_LIST generic);
+  
+}


### PR DESCRIPTION
I add new annotation for code generator - GenTypeParams.
This can be used to remove wildcards in generated code but leave them in Java.
This is required for https://github.com/eclipse/vert.x/pull/1994 to build.