### PR TITLE
Fixed bug in traversal of json arrays/maps

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -2,6 +2,7 @@ package io.vertx.core.json;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -25,5 +26,7 @@ public class JsonArray implements Iterable<Object> {
   public List getList() {
     throw new UnsupportedOperationException();
   }
-
+  public Stream<Object> stream() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -1,6 +1,7 @@
 package io.vertx.core.json;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -38,6 +39,9 @@ public class JsonObject  {
   public JsonArray getJsonArray(String name) { throw new UnsupportedOperationException(); }
   public byte[] getBinary(String name) { throw new UnsupportedOperationException(); }
   public Map<String, Object> getMap() {
+    throw new UnsupportedOperationException();
+  }
+  public Stream<Map.Entry<String, Object>> stream() {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
@@ -29,8 +29,7 @@ public class DataObjectWithLists {
   private static <T> List<T> fromArray(JsonObject obj, String name, Function<Object, T> converter) {
     JsonArray array = obj.getJsonArray(name);
     if (array != null) {
-      List<?> list = array.getList();
-      return list.stream().map(converter).collect(Collectors.toList());
+      return array.stream().map(converter).collect(Collectors.toList());
     } else {
       return null;
     }

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
@@ -1,14 +1,13 @@
 package io.vertx.codegen.testmodel;
 
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -35,9 +34,8 @@ public class DataObjectWithMaps {
   private static <T> Map<String, T> fromObject(JsonObject obj, String name, Function<Object, T> converter) {
     JsonObject array = obj.getJsonObject(name);
     if (array != null) {
-      Map<String, Object> map = array.getMap();
-      map.entrySet().forEach(entry -> entry.setValue(converter.apply(entry.getValue())));
-      return (Map<String, T>) map;
+      return array.stream()
+        .collect(Collectors.toMap(entry -> entry.getKey(), entry -> converter.apply(entry.getValue())));
     } else {
       return null;
     }


### PR DESCRIPTION
This produced inconsistencies when the backing list/map contained json wrappers
such as JsonArray/JsonObject or backing List/Map. Use the new stream() method
to always view wrapped values to remove inconsistencies.