### PR TITLE
Type use fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,6 @@
   </dependencyManagement>
 
   <dependencies>
-
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.8</version>
-      <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
-      <optional>true</optional>
-    </dependency>
-
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
@@ -231,4 +221,29 @@
 	  </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>tools</id>
+      <properties>
+        <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
+      </properties>
+      <activation>
+        <property>
+          <name>!notools</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.8</version>
+          <scope>system</scope>
+          <systemPath>${tools.jar}</systemPath>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,16 @@
   </dependencyManagement>
 
   <dependencies>
+
+    <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+      <version>1.8</version>
+      <scope>system</scope>
+      <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>

--- a/src/main/java/io/vertx/codegen/CodeGen.java
+++ b/src/main/java/io/vertx/codegen/CodeGen.java
@@ -38,12 +38,14 @@ public class CodeGen {
   private final HashMap<String, TypeElement> enums = new HashMap<>();
   private final HashMap<String, PackageElement> modules = new HashMap<>();
   private final HashMap<String, TypeElement> proxyClasses = new HashMap<>();
+  private final ProcessingEnvironment env;
   private final Elements elementUtils;
   private final Types typeUtils;
   private final Messager messager;
   private final MethodOverloadChecker methodOverloadChecker = new MethodOverloadChecker();
 
   public CodeGen(ProcessingEnvironment env, RoundEnvironment round) {
+    this.env = env;
     this.messager = env.getMessager();
     this.elementUtils = env.getElementUtils();
     this.typeUtils = env.getTypeUtils();
@@ -158,7 +160,7 @@ public class CodeGen {
     if (element == null) {
       throw new IllegalArgumentException("Source for " + fqcn + " not found");
     } else {
-      ClassModel model = new ClassModel(methodOverloadChecker, messager, classes, elementUtils, typeUtils, element);
+      ClassModel model = new ClassModel(env, methodOverloadChecker, messager, classes, elementUtils, typeUtils, element);
       model.process();
       return model;
     }
@@ -191,7 +193,7 @@ public class CodeGen {
     if (element == null) {
       throw new IllegalArgumentException("Source for " + fqcn + " not found");
     } else {
-      ProxyModel model = new ProxyModel(methodOverloadChecker, messager, classes, elementUtils, typeUtils, element);
+      ProxyModel model = new ProxyModel(env, methodOverloadChecker, messager, classes, elementUtils, typeUtils, element);
       model.process();
       return model;
     }

--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -17,6 +17,7 @@ import javax.annotation.processing.FilerException;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
@@ -333,7 +334,11 @@ public class CodeGenProcessor extends AbstractProcessor {
   }
 
   private void reportGenException(GenException e) {
-    String msg = "Could not generate model for " + e.element + ": " + e.msg;
+    String name = e.element.toString();
+    if (e.element.getKind() == ElementKind.METHOD) {
+      name = e.element.getEnclosingElement() + "#" + name;
+    }
+    String msg = "Could not generate model for " + name + ": " + e.msg;
     log.log(Level.SEVERE, msg, e);
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, e.element);
   }

--- a/src/main/java/io/vertx/codegen/Helper.java
+++ b/src/main/java/io/vertx/codegen/Helper.java
@@ -613,7 +613,7 @@ public class Helper {
    * @param modelMethod the model method element
    * @return the method or null if not found
    */
-  static Method getReflectMethod(ExecutableElement modelMethod) {
+  public static Method getReflectMethod(ExecutableElement modelMethod) {
     TypeElement typeElt = (TypeElement) modelMethod.getEnclosingElement();
     Method method = null;
     try {

--- a/src/main/java/io/vertx/codegen/ParamInfo.java
+++ b/src/main/java/io/vertx/codegen/ParamInfo.java
@@ -72,16 +72,9 @@ public class ParamInfo {
       case HANDLER:
         TypeInfo handler = ((ParameterizedTypeInfo)type).getArg(0);
         switch (handler.getKind()) {
-          case OBJECT:
-            return true;
           case ASYNC_RESULT:
             TypeInfo asyncResult = ((ParameterizedTypeInfo)handler).getArg(0);
-            switch (asyncResult.getKind()) {
-              case OBJECT:
-                return true;
-              default:
-                return asyncResult.isNullable();
-            }
+            return asyncResult.isNullable();
           default:
             return handler.isNullable();
         }

--- a/src/main/java/io/vertx/codegen/ProxyModel.java
+++ b/src/main/java/io/vertx/codegen/ProxyModel.java
@@ -24,6 +24,7 @@ import io.vertx.codegen.overloadcheck.MethodOverloadChecker;
 import io.vertx.codegen.type.*;
 
 import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -43,8 +44,8 @@ import java.util.Set;
  */
 public class ProxyModel extends ClassModel {
 
-  public ProxyModel(MethodOverloadChecker methodOverloadChecker, Messager messager, Map<String, TypeElement> sources, Elements elementUtils, Types typeUtils, TypeElement modelElt) {
-    super(methodOverloadChecker, messager, sources, elementUtils, typeUtils, modelElt);
+  public ProxyModel(ProcessingEnvironment env, MethodOverloadChecker methodOverloadChecker, Messager messager, Map<String, TypeElement> sources, Elements elementUtils, Types typeUtils, TypeElement modelElt) {
+    super(env, methodOverloadChecker, messager, sources, elementUtils, typeUtils, modelElt);
   }
 
   @Override

--- a/src/main/java/io/vertx/codegen/type/TreeTypeInternal.java
+++ b/src/main/java/io/vertx/codegen/type/TreeTypeInternal.java
@@ -1,0 +1,95 @@
+package io.vertx.codegen.type;
+
+import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.tree.JCTree;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class TreeTypeInternal implements TypeUse.TypeInternal {
+
+  static final TypeUse.TypeInternalProvider PROVIDER = new TypeUse.TypeInternalProvider() {
+    public TypeUse.TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int paramIndex) {
+      Trees trees = Trees.instance(env);
+      if (trees == null) {
+        return null;
+      }
+      MethodTree tree = trees.getTree(methodElt);
+      if (tree == null) {
+        return null;
+      }
+      return new TreeTypeInternal(tree.getParameters().get(paramIndex).getType());
+    }
+    public TypeUse.TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt) {
+      Trees trees = Trees.instance(env);
+      if (trees == null) {
+        return null;
+      }
+      MethodTree tree = trees.getTree(methodElt);
+      if (tree == null) {
+        return null;
+      }
+      return new TreeTypeInternal(tree.getReturnType());
+    }
+
+  };
+
+  private final Tree type;
+  private final boolean nullable;
+
+  private TreeTypeInternal(Tree type) {
+    this.type = type;
+    this.nullable = isNullable(type);
+  }
+
+  public boolean isNullable() {
+    return nullable;
+  }
+
+  public TypeUse.TypeInternal getArgAt(int index) {
+    if (type instanceof ParameterizedTypeTree) {
+      ParameterizedTypeTree parameterizedType = (ParameterizedTypeTree) type;
+      return new TreeTypeInternal(parameterizedType.getTypeArguments().get(index));
+    } else {
+      return TypeUse.NULL_TYPE_INTERNAL;
+    }
+  }
+
+  private static boolean isNullable(Tree type) {
+    TypeMirror typeMirror = ((JCTree)type).type;
+    if (typeMirror instanceof com.sun.tools.javac.code.Type.AnnotatedType) {
+      com.sun.tools.javac.code.Type.AnnotatedType abc = (com.sun.tools.javac.code.Type.AnnotatedType) typeMirror;
+      for (AnnotationMirror mirror : abc.getAnnotationMirrors()) {
+        if (mirror.getAnnotationType().toString().equals(TypeUse.NULLABLE)) {
+          return true;
+        }
+      }
+    }
+    if (type instanceof JCTree.JCTypeApply) {
+      JCTree.JCExpression expr = ((JCTree.JCTypeApply) type).clazz;
+      if (expr instanceof AnnotatedTypeTree) {
+        AnnotatedTypeTree tree2 = (AnnotatedTypeTree) expr;
+        for (AnnotationTree mirror : tree2.getAnnotations()) {
+          if (mirror instanceof JCTree.JCAnnotation) {
+            JCTree.JCAnnotation jca = (JCTree.JCAnnotation) mirror;
+            if (jca.type.toString().equals(TypeUse.NULLABLE)) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/io/vertx/codegen/type/TypeUse.java
+++ b/src/main/java/io/vertx/codegen/type/TypeUse.java
@@ -1,11 +1,5 @@
 package io.vertx.codegen.type;
 
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.ParameterizedTypeTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
-import com.sun.source.util.Trees;
-import com.sun.tools.javac.tree.JCTree;
 import io.vertx.codegen.Helper;
 import io.vertx.codegen.annotations.Nullable;
 
@@ -13,19 +7,14 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * What we need to use from type use annotations, wether it uses <i>lang model</i> api
@@ -33,118 +22,89 @@ import java.util.stream.Stream;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public abstract class TypeUse {
+public class TypeUse {
 
-  private static final String NULLABLE = Nullable.class.getName();
+  static final String NULLABLE = Nullable.class.getName();
+  private static final List<TypeInternalProvider> providers = new ArrayList<>();
 
-  /**
-   * Create a type use for reflect types.
-   *
-   * @param reflectTypes the annotated types
-   * @return the created type use
-   */
-  public static TypeUse createTypeUse(AnnotatedType... reflectTypes) {
-    return new TypeUse() {
-
-      public TypeUse getArg(int index) {
-
-        AnnotatedType arg = ((AnnotatedParameterizedType) reflectTypes[0]).getAnnotatedActualTypeArguments()[index];
-        List<AnnotatedType> argAnnotatedTypes = new ArrayList<>();
-
-        // The first one is the actual type so we add it
-        argAnnotatedTypes.add(arg);
-
-        //
-        ParameterizedType pt = (ParameterizedType) reflectTypes[0].getType();
-        Type[] typeArgs = pt.getActualTypeArguments();
-        TypeVariable<? extends Class<?>>[] typeVars = ((Class<?>) pt.getRawType()).getTypeParameters();
-
-        // For all other types (i.e >= 1) when it's a parameterized type, this type can only be
-        // a super type of the first annotated type
-        // we need to find out
-        // if one of its type parameters matches the actual argument we need
-        for (int i = 1;i < reflectTypes.length;i++) {
-          if (reflectTypes[i].getType() instanceof ParameterizedType) {
-            ParameterizedType a = (ParameterizedType) reflectTypes[i].getType();
-            TypeVariable[] typeParam = ((Class<?>) a.getRawType()).getTypeParameters();
-            for (int j = 0;j < typeParam.length;j++) {
-              Type resolved = Helper.resolveTypeParameter(pt, typeParam[j]);
-              if (resolved != null) {
-                if (typeArgs[index].equals(resolved)) {
-                  argAnnotatedTypes.add(((AnnotatedParameterizedType) reflectTypes[i]).getAnnotatedActualTypeArguments()[j]);
-                }
-              }
-            }
-          }
+  static {
+    try {
+      // Java 8 compiler has incomplete implementation of type use API
+      providers.add(TreeTypeInternal.PROVIDER);
+    } catch (Throwable ignore) {
+      // Java 9 compiler - Trees are not available but type use via mirror should work fine
+    }
+    providers.add(new TypeInternalProvider() {
+      public TypeUse.TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int paramIndex) {
+        Method methodRef = Helper.getReflectMethod(methodElt);
+        if (methodRef == null) {
+          return null;
         }
-        return createTypeUse(argAnnotatedTypes.toArray(new AnnotatedType[argAnnotatedTypes.size()]));
+        AnnotatedType annotated = methodRef.getAnnotatedParameterTypes()[paramIndex];
+        return new ReflectType(annotated);
       }
-
-      public boolean isNullable() {
-        boolean nullable = false;
-        for (int index = 0;index < reflectTypes.length;index++) {
-          if (isNullable(index)) {
-            nullable = true;
-          } else {
-            if (nullable) {
-              throw new RuntimeException("Nullable type cannot override non nullable");
-            }
-          }
+      public TypeUse.TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt) {
+        Method methodRef = Helper.getReflectMethod(methodElt);
+        if (methodRef == null) {
+          return null;
         }
-        return nullable;
+        AnnotatedType annotated = methodRef.getAnnotatedReturnType();
+        return new ReflectType(annotated);
       }
-
-      private boolean isNullable(int index) {
-        for (Annotation annotation : reflectTypes[index].getAnnotations()) {
-          if (annotation.annotationType().getName().equals(NULLABLE)) {
-            return true;
-          }
-        }
-        return false;
+    });
+    providers.add(new TypeInternalProvider() {
+      @Override
+      public TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int index) {
+        return new MirrorTypeInternal(methodElt.getParameters().get(index).asType());
       }
-    };
+      @Override
+      public TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt) {
+        return new MirrorTypeInternal(methodElt.getReturnType());
+      }
+    });
   }
 
-  /**
-   * Create a type use for model types.
-   *
-   * @param modelTypes the annotated types
-   * @return the created type use
-   */
-  public static TypeUse createTypeUse(TypeMirror... modelTypes) {
-    return new TypeUse() {
-      @Override
-      public TypeUse getArg(int index) {
-        // Only use the current types as the other types won't have the info anyway
-        return createTypeUse(((DeclaredType) modelTypes[0]).getTypeArguments().get(index));
-      }
+  interface TypeInternal {
+    boolean isNullable();
+    TypeInternal getArgAt(int index);
+  }
 
-      @Override
-      public boolean isNullable() {
-        boolean nullable = false;
-        for (int index = 0;index < modelTypes.length;index++) {
-          if (isNullable(index)) {
-            nullable = true;
-          } else {
-            if (nullable) {
-              throw new RuntimeException("Nullable type cannot override non nullable");
-            }
-          }
-        }
-        return nullable;
-      }
+  interface TypeInternalProvider {
+    TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int index);
+    TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt);
+  }
 
-      private boolean isNullable(int index) {
-        for (AnnotationMirror annotation : modelTypes[index].getAnnotationMirrors()) {
-          DeclaredType annotationType = annotation.getAnnotationType();
-          TypeElement annotationTypeElt = (TypeElement) annotationType.asElement();
-          if (annotationTypeElt.getQualifiedName().toString().equals(NULLABLE)) {
-            return true;
-          }
+
+  public static TypeUse createParamTypeUse(ProcessingEnvironment env, ExecutableElement[] methods, int index) {
+    TypeInternal[] internals = new TypeInternal[methods.length];
+    for (int i = 0;i < methods.length;i++) {
+      for (TypeInternalProvider provider : providers) {
+        internals[i] = provider.forParam(env, methods[i], index);
+        if (internals[i] != null) {
+          break;
         }
-        return false;
       }
-    };
+    }
+    return new TypeUse(internals);
+  }
+
+  public static TypeUse createReturnTypeUse(ProcessingEnvironment env, ExecutableElement... methods) {
+    TypeInternal[] internals = new TypeInternal[methods.length];
+    for (int i = 0;i < methods.length;i++) {
+      for (TypeInternalProvider provider : providers) {
+        internals[i] = provider.forReturn(env, methods[i]);
+        if (internals[i] != null) {
+          break;
+        }
+      }
+    }
+    return new TypeUse(internals);
+  }
+
+  private final TypeInternal[] types;
+
+  private TypeUse(TypeInternal[] types) {
+    this.types = types;
   }
 
   /**
@@ -153,149 +113,101 @@ public abstract class TypeUse {
    * @param index the argument index
    * @return the type use
    */
-  public abstract TypeUse getArg(int index);
+  public TypeUse getArg(int index) {
+    TypeInternal[] abc = new TypeInternal[types.length];
+    for (int i = 0;i < types.length;i++) {
+      abc[i] = types[i].getArgAt(index);
+    }
+    return new TypeUse(abc);
+  }
 
   /**
    * @return true if the type is nullable
    */
-  public abstract  boolean isNullable();
-
-  private static TypeUse NULL_TYPE_USE = new TypeUse() {
-    @Override
-    public TypeUse getArg(int index) {
-      return NULL_TYPE_USE;
+  public boolean isNullable() {
+    boolean nullable = false;
+    for (TypeInternal type : types) {
+      if (type.isNullable()) {
+        nullable = true;
+      } else {
+        if (nullable) {
+          throw new RuntimeException("Nullable type cannot override non nullable");
+        }
+      }
     }
+    return nullable;
+  }
+
+  static TypeInternal NULL_TYPE_INTERNAL = new TypeInternal() {
     @Override
     public boolean isNullable() {
       return false;
     }
+    @Override
+    public TypeInternal getArgAt(int index) {
+      return NULL_TYPE_INTERNAL;
+    }
   };
 
-  private interface InternalType {
-    boolean isNullable();
-    InternalType getArgAt(int index);
-  }
+  private static class ReflectType implements TypeInternal {
 
-  private static class ReflectType implements InternalType {
-    final Type type;
-    final boolean nullable;
+    private final AnnotatedType annotatedType;
+    private final boolean nullable;
+
     private ReflectType(AnnotatedType annotated) {
-      this.type = annotated.getType();
-      this.nullable = TypeUse.isNullable(annotated);
+      this.annotatedType = annotated;
+      this.nullable = isNullable(annotated);
     }
+
     public boolean isNullable() {
       return nullable;
     }
-    public InternalType getArgAt(int index) {
-      throw new UnsupportedOperationException();
-    }
-  }
 
-  private static class MirrorType implements InternalType {
-    final Tree type;
-    final boolean nullable;
-    private MirrorType(Tree type) {
-      this.type = type;
-      this.nullable = TypeUse.isNullable(type);
-    }
-    public boolean isNullable() {
-      return nullable;
-    }
-    public InternalType getArgAt(int index) {
-      ParameterizedTypeTree parameterizedType = (ParameterizedTypeTree) type;
-      return new MirrorType(parameterizedType.getTypeArguments().get(index));
-    }
-  }
-
-  public static TypeUse createParamTypeUse(ProcessingEnvironment env, ExecutableElement[] methods, int index) {
-    Trees trees = Trees.instance(env);
-    InternalType[] abc = new InternalType[methods.length];
-    for (int i = 0;i < methods.length;i++) {
-      MethodTree tree = trees.getTree(methods[i]);
-      if (tree != null) {
-        VariableTree def = tree.getParameters().get(index);
-        abc[i] = new MirrorType(def.getType());
+    public TypeInternal getArgAt(int index) {
+      if (annotatedType instanceof AnnotatedParameterizedType) {
+        AnnotatedParameterizedType annotatedParameterizedType = (AnnotatedParameterizedType) annotatedType;
+        return new ReflectType(annotatedParameterizedType.getAnnotatedActualTypeArguments()[index]);
       } else {
-/*
-        Method methodRef = Helper.getReflectMethod(methods[i]);
-        if (methodRef != null) {
-          AnnotatedType annotated = methodRef.getAnnotatedParameterTypes()[index];
-          abc[i] = new ReflectType(annotated);
-        }
-*/
-//        throw new UnsupportedOperationException("Cannot get parameter type " + index + " of " + methods[i].getEnclosingElement() + "#" +  methods[i]);
-        return createTypeUse(Stream.of(methods).map(m -> m.getParameters().get(index).asType()).toArray(TypeMirror[]::new));
+        return NULL_TYPE_INTERNAL;
       }
     }
-    return createTypeUse(abc);
-  }
 
-  public static TypeUse createReturnTypeUse(ProcessingEnvironment env, ExecutableElement... methods) {
-    Trees trees = Trees.instance(env);
-    InternalType[] abc = new InternalType[methods.length];
-    for (int i = 0; i < methods.length;i++) {
-      MethodTree tree = trees.getTree(methods[i]);
-      if (tree != null) {
-        abc[i] = new MirrorType(tree.getReturnType());
-      } else {
-/*
-        Method methodRef = Helper.getReflectMethod(methods[i]);
-        if (methodRef != null) {
-          AnnotatedType annotated = methodRef.getAnnotatedReturnType();
-          abc[i] = new ReflectType(annotated);
-        }
-*/
-//        throw new UnsupportedOperationException("Cannot get return type of " + methods[i].getEnclosingElement() + "#" + methods[i]);
-        return createTypeUse(Stream.of(methods).map(ExecutableElement::getReturnType).toArray(TypeMirror[]::new));
-      }
-    }
-    return createTypeUse(abc);
-  }
-
-  private static boolean isNullable(Tree type) {
-    TypeMirror typeMirror = ((JCTree)type).type;
-    if (typeMirror instanceof com.sun.tools.javac.code.Type.AnnotatedType) {
-      com.sun.tools.javac.code.Type.AnnotatedType abc = (com.sun.tools.javac.code.Type.AnnotatedType) typeMirror;
-      for (AnnotationMirror mirror : abc.getAnnotationMirrors()) {
-        if (mirror.getAnnotationType().toString().equals(NULLABLE)) {
+    private static boolean isNullable(AnnotatedType type) {
+      for (Annotation annotation : type.getAnnotations()) {
+        if (annotation.annotationType().getName().equals(NULLABLE)) {
           return true;
         }
       }
+      return false;
     }
-    return false;
   }
 
-  private static boolean isNullable(AnnotatedType type) {
-    for (Annotation annotation : type.getAnnotations()) {
-      if (annotation.annotationType().getName().equals(NULLABLE)) {
-        return true;
-      }
-    }
-    return false;
-  }
+  private static class MirrorTypeInternal implements TypeInternal {
 
-  private static TypeUse createTypeUse(InternalType... types) {
-    return new TypeUse() {
-      @Override
-      public TypeUse getArg(int index) {
-        return TypeUse.createTypeUse(types[0].getArgAt(index));
-      }
-      @Override
-      public boolean isNullable() {
-        boolean nullable = false;
-        for (InternalType type : types) {
-          if (type.isNullable()) {
-            nullable = true;
-          } else {
-            if (nullable) {
-              throw new RuntimeException("Nullable type cannot override non nullable");
-            }
-          }
+    final TypeMirror mirror;
+
+    private MirrorTypeInternal(TypeMirror mirror) {
+      this.mirror = mirror;
+    }
+
+    public boolean isNullable() {
+      for (AnnotationMirror annotation : mirror.getAnnotationMirrors()) {
+        DeclaredType annotationType = annotation.getAnnotationType();
+        TypeElement annotationTypeElt = (TypeElement) annotationType.asElement();
+        if (annotationTypeElt.getQualifiedName().toString().equals(NULLABLE)) {
+          return true;
         }
-        return nullable;
       }
-    };
+      return false;
+    }
+
+    public TypeInternal getArgAt(int index) {
+      List<? extends TypeMirror> args = ((DeclaredType) mirror).getTypeArguments();
+      if (index < args.size()) {
+        return new MirrorTypeInternal(args.get(index));
+      } else {
+        return NULL_TYPE_INTERNAL;
+      }
+    }
   }
-
-
 }

--- a/src/main/java/io/vertx/codegen/type/TypeUse.java
+++ b/src/main/java/io/vertx/codegen/type/TypeUse.java
@@ -1,20 +1,31 @@
 package io.vertx.codegen.type;
 
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.tree.JCTree;
 import io.vertx.codegen.Helper;
 import io.vertx.codegen.annotations.Nullable;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * What we need to use from type use annotations, wether it uses <i>lang model</i> api
@@ -148,5 +159,143 @@ public abstract class TypeUse {
    * @return true if the type is nullable
    */
   public abstract  boolean isNullable();
+
+  private static TypeUse NULL_TYPE_USE = new TypeUse() {
+    @Override
+    public TypeUse getArg(int index) {
+      return NULL_TYPE_USE;
+    }
+    @Override
+    public boolean isNullable() {
+      return false;
+    }
+  };
+
+  private interface InternalType {
+    boolean isNullable();
+    InternalType getArgAt(int index);
+  }
+
+  private static class ReflectType implements InternalType {
+    final Type type;
+    final boolean nullable;
+    private ReflectType(AnnotatedType annotated) {
+      this.type = annotated.getType();
+      this.nullable = TypeUse.isNullable(annotated);
+    }
+    public boolean isNullable() {
+      return nullable;
+    }
+    public InternalType getArgAt(int index) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class MirrorType implements InternalType {
+    final Tree type;
+    final boolean nullable;
+    private MirrorType(Tree type) {
+      this.type = type;
+      this.nullable = TypeUse.isNullable(type);
+    }
+    public boolean isNullable() {
+      return nullable;
+    }
+    public InternalType getArgAt(int index) {
+      ParameterizedTypeTree parameterizedType = (ParameterizedTypeTree) type;
+      return new MirrorType(parameterizedType.getTypeArguments().get(index));
+    }
+  }
+
+  public static TypeUse createParamTypeUse(ProcessingEnvironment env, ExecutableElement[] methods, int index) {
+    Trees trees = Trees.instance(env);
+    InternalType[] abc = new InternalType[methods.length];
+    for (int i = 0;i < methods.length;i++) {
+      MethodTree tree = trees.getTree(methods[i]);
+      if (tree != null) {
+        VariableTree def = tree.getParameters().get(index);
+        abc[i] = new MirrorType(def.getType());
+      } else {
+/*
+        Method methodRef = Helper.getReflectMethod(methods[i]);
+        if (methodRef != null) {
+          AnnotatedType annotated = methodRef.getAnnotatedParameterTypes()[index];
+          abc[i] = new ReflectType(annotated);
+        }
+*/
+//        throw new UnsupportedOperationException("Cannot get parameter type " + index + " of " + methods[i].getEnclosingElement() + "#" +  methods[i]);
+        return createTypeUse(Stream.of(methods).map(m -> m.getParameters().get(index).asType()).toArray(TypeMirror[]::new));
+      }
+    }
+    return createTypeUse(abc);
+  }
+
+  public static TypeUse createReturnTypeUse(ProcessingEnvironment env, ExecutableElement... methods) {
+    Trees trees = Trees.instance(env);
+    InternalType[] abc = new InternalType[methods.length];
+    for (int i = 0; i < methods.length;i++) {
+      MethodTree tree = trees.getTree(methods[i]);
+      if (tree != null) {
+        abc[i] = new MirrorType(tree.getReturnType());
+      } else {
+/*
+        Method methodRef = Helper.getReflectMethod(methods[i]);
+        if (methodRef != null) {
+          AnnotatedType annotated = methodRef.getAnnotatedReturnType();
+          abc[i] = new ReflectType(annotated);
+        }
+*/
+//        throw new UnsupportedOperationException("Cannot get return type of " + methods[i].getEnclosingElement() + "#" + methods[i]);
+        return createTypeUse(Stream.of(methods).map(ExecutableElement::getReturnType).toArray(TypeMirror[]::new));
+      }
+    }
+    return createTypeUse(abc);
+  }
+
+  private static boolean isNullable(Tree type) {
+    TypeMirror typeMirror = ((JCTree)type).type;
+    if (typeMirror instanceof com.sun.tools.javac.code.Type.AnnotatedType) {
+      com.sun.tools.javac.code.Type.AnnotatedType abc = (com.sun.tools.javac.code.Type.AnnotatedType) typeMirror;
+      for (AnnotationMirror mirror : abc.getAnnotationMirrors()) {
+        if (mirror.getAnnotationType().toString().equals(NULLABLE)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isNullable(AnnotatedType type) {
+    for (Annotation annotation : type.getAnnotations()) {
+      if (annotation.annotationType().getName().equals(NULLABLE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static TypeUse createTypeUse(InternalType... types) {
+    return new TypeUse() {
+      @Override
+      public TypeUse getArg(int index) {
+        return TypeUse.createTypeUse(types[0].getArgAt(index));
+      }
+      @Override
+      public boolean isNullable() {
+        boolean nullable = false;
+        for (InternalType type : types) {
+          if (type.isNullable()) {
+            nullable = true;
+          } else {
+            if (nullable) {
+              throw new RuntimeException("Nullable type cannot override non nullable");
+            }
+          }
+        }
+        return nullable;
+      }
+    };
+  }
+
 
 }

--- a/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
@@ -12,15 +12,21 @@ import io.vertx.codegen.testmodel.TestEnum;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.codegen.testapi.VertxGenClass1;
+import io.vertx.test.codegen.testapi.nullable.MethodWithNullableParams;
+import io.vertx.test.codegen.testapi.nullable.MethodWithNullableInheritedParams;
+import io.vertx.test.codegen.testapi.nullable.MethodWithNullableReturn;
 import io.vertx.test.codegen.testapi.nullable.DiamondGenericBottomFluentNullableParam;
+import io.vertx.test.codegen.testapi.nullable.MethodWithCovariantNullableReturn;
 import io.vertx.test.codegen.testapi.nullable.InterfaceWithInvalidListNullableParamOverride;
 import io.vertx.test.codegen.testapi.nullable.InterfaceWithInvalidNullableParamOverride;
 import io.vertx.test.codegen.testapi.nullable.InterfaceWithInvalidNullableReturnOverride;
+import io.vertx.test.codegen.testapi.nullable.InterfaceWithNonNullableParams;
 import io.vertx.test.codegen.testapi.nullable.InterfaceWithNullableReturnMethod;
 import io.vertx.test.codegen.testapi.nullable.MethodWithInvalidNullableTypeArgumentHandler;
 import io.vertx.test.codegen.testapi.nullable.MethodWithInvalidNullableTypeArgumentHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithInvalidNullableTypeArgumentParam;
 import io.vertx.test.codegen.testapi.nullable.MethodWithInvalidNullableTypeArgumentReturn;
+import io.vertx.test.codegen.testapi.nullable.MethodWithListNullableParam;
 import io.vertx.test.codegen.testapi.nullable.MethodWithListNullableParamOverride;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableNonAnnotatedObjectParam;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableNonAnnotatedTypeVariableHandlerAsyncResult;
@@ -46,7 +52,7 @@ import io.vertx.test.codegen.testapi.nullable.MethodWithInvalidOverloadedNullabl
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableHandler;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableParam;
-import io.vertx.test.codegen.testapi.nullable.MethodWithNullableReturn;
+import io.vertx.test.codegen.testapi.nullable.MethodWithNullableReturns;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableStringHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeArgReturn;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableHandlerAsyncResult;
@@ -56,11 +62,13 @@ import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableRetu
 import io.vertx.test.codegen.testapi.nullable.MethodWithOverloadedNullableParam;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -90,11 +98,13 @@ public class ClassNullableTest extends ClassTestBase {
 
   @Test
   public void testInterfaceWithInvalidNullableParamOverride() throws Exception {
+    assertGenInvalid(InterfaceWithInvalidNullableParamOverride.class, InterfaceWithNonNullableParams.class);
     assertGenInvalid(InterfaceWithInvalidNullableParamOverride.class);
   }
 
   @Test
   public void testInterfaceWithInvalidListNullableParamOverride() throws Exception {
+    assertGenInvalid(InterfaceWithInvalidListNullableParamOverride.class, InterfaceWithNonNullableParams.class);
     assertGenInvalid(InterfaceWithInvalidListNullableParamOverride.class);
   }
 
@@ -222,11 +232,38 @@ public class ClassNullableTest extends ClassTestBase {
 
   @Test
   public void testInterfaceWithListNullableParamOverride() throws Exception {
-    ClassModel model = new Generator().generateClass(MethodWithListNullableParamOverride.class);
-    List<MethodInfo> methods = model.getMethods();
-    assertEquals(1, methods.size());
-    MethodInfo mi2 = methods.get(0);
-    assertTrue(((ParameterizedTypeInfo) mi2.getParams().get(0).getType()).getArg(0).isNullable());
+    generateClass(model -> {
+      List<MethodInfo> methods = model.getMethods();
+      assertEquals(1, methods.size());
+      MethodInfo mi2 = methods.get(0);
+      assertTrue(((ParameterizedTypeInfo) mi2.getParams().get(0).getType()).getArg(0).isNullable());
+    }, MethodWithListNullableParamOverride.class, MethodWithListNullableParam.class);
+  }
+
+  @Test
+  public void testMethodWithNullableInheritedParams() throws Exception {
+    Consumer<ClassModel> check = model -> {
+      List<MethodInfo> methods = model.getMethods();
+      assertEquals(1, methods.size());
+      MethodInfo mi2 = methods.get(0);
+      assertTrue(mi2.getParams().get(0).getType().isNullable());
+      assertTrue(((ParameterizedTypeInfo) mi2.getParams().get(1).getType()).getArg(0).isNullable());
+      assertTrue(((ParameterizedTypeInfo) ((ParameterizedTypeInfo) mi2.getParams().get(2).getType()).getArg(0)).getArg(0).isNullable());
+    };
+    generateClass(check, MethodWithNullableInheritedParams.class, MethodWithNullableParams.class);
+    generateClass(check, MethodWithNullableInheritedParams.class);
+  }
+
+  @Test
+  public void testMethodWithCovariantNullableReturn() throws Exception {
+    Consumer<ClassModel> check = model -> {
+      List<MethodInfo> methods = model.getMethods();
+      assertEquals(1, methods.size());
+      MethodInfo mi2 = methods.get(0);
+      assertTrue(mi2.getReturnType().isNullable());
+    };
+    generateClass(check, MethodWithCovariantNullableReturn.class, MethodWithNullableReturn.class);
+    generateClass(check, MethodWithCovariantNullableReturn.class);
   }
 
   @Test
@@ -350,7 +387,7 @@ public class ClassNullableTest extends ClassTestBase {
   // Valid returns
 
   @Test
-  public <T> void testMethodWithNullableReturn() throws Exception {
+  public <T> void testMethodWithNullableReturns() throws Exception {
     AtomicBoolean checkModel = new AtomicBoolean();
     TypeLiteral<T> typeLiteral = new TypeLiteral<T>() {};
     generateClass(model -> {
@@ -413,7 +450,7 @@ public class ClassNullableTest extends ClassTestBase {
       methods.forEach(m -> {
         assertTrue("Expects " + m.getName() + " to have nullable return type", m.isNullableReturn());
       });
-    }, MethodWithNullableReturn.class);
+    }, MethodWithNullableReturns.class);
   }
 
   @Test
@@ -503,26 +540,48 @@ public class ClassNullableTest extends ClassTestBase {
     }, MethodWithNullableNonAnnotatedTypeVariableReturn.class);
   }
 
-  private void generateClass(Consumer<ClassModel> test, Class<?> clazz, Class<?>... rest) throws Exception {
-//    ClassModel model = new Generator().generateClass(clazz);
-//    test.accept(model);
+  private void blacklist(Class<?> clazz, Class<?>[] rest, Runnable test) {
+    Set<String> blacklist = new HashSet<>();
+    blacklist.add(clazz.getName());
+    Stream.of(rest).map(Class::getName).forEach(blacklist::add);
     Thread thread = Thread.currentThread();
     ClassLoader prev = thread.getContextClassLoader();
     thread.setContextClassLoader(new ClassLoader(prev) {
       @Override
       public Class<?> loadClass(String name) throws ClassNotFoundException {
-        if (name.startsWith("io.vertx.test.codegen.testapi.nullable.")) {
+        if (blacklist.contains(name)) {
           throw new ClassNotFoundException();
         }
         return super.loadClass(name);
       }
     });
-    ClassModel model;
     try {
-      model = new Generator().generateClass(clazz, rest);
+      test.run();
     } finally {
       thread.setContextClassLoader(prev);
     }
-    test.accept(model);
+  }
+
+  private void generateClass(Consumer<ClassModel> test, Class<?> clazz, Class<?>... rest) throws Exception {
+//    ClassModel model = new Generator().generateClass(clazz);
+//    test.accept(model);
+    blacklist(clazz, rest, () -> {
+      try {
+        test.accept(new Generator().generateClass(clazz, rest));
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+    });
+  }
+
+  @Override
+  void assertGenInvalid(Class<?> c, Class<?>... rest) throws Exception {
+    blacklist(c, rest, () -> {
+      try {
+        ClassNullableTest.super.assertGenInvalid(c, rest);
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
+    });
   }
 }

--- a/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
@@ -47,6 +47,7 @@ import io.vertx.test.codegen.testapi.nullable.MethodWithNullableHandler;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableParam;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableReturn;
+import io.vertx.test.codegen.testapi.nullable.MethodWithNullableStringHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeArgReturn;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableHandlerAsyncResult;
 import io.vertx.test.codegen.testapi.nullable.MethodWithNullableTypeVariableHandler;
@@ -304,6 +305,17 @@ public class ClassNullableTest extends ClassTestBase {
   }
 
   @Test
+  public void testMethodWithNullableStringHandlerAsyncResult() throws Exception {
+    generateClass(model -> {
+      List<MethodInfo> methods = model.getMethods();
+      assertEquals(1, methods.size());
+      MethodInfo mi1 = methods.get(0);
+      checkMethod(mi1, "method", 1, "void", MethodKind.FUTURE);
+      assertTrue(mi1.getParams().get(0).isNullableCallback());
+    }, MethodWithNullableStringHandlerAsyncResult.class);
+  }
+
+  @Test
   public void testMethodWithNullableNonAnnotatedTypeVariableHandlerAsyncResult() throws Exception {
     generateClass(model -> {
       List<MethodInfo> methods = model.getMethods();
@@ -492,8 +504,8 @@ public class ClassNullableTest extends ClassTestBase {
   }
 
   private void generateClass(Consumer<ClassModel> test, Class<?> clazz, Class<?>... rest) throws Exception {
-    ClassModel model = new Generator().generateClass(clazz);
-    test.accept(model);
+//    ClassModel model = new Generator().generateClass(clazz);
+//    test.accept(model);
     Thread thread = Thread.currentThread();
     ClassLoader prev = thread.getContextClassLoader();
     thread.setContextClassLoader(new ClassLoader(prev) {
@@ -505,6 +517,7 @@ public class ClassNullableTest extends ClassTestBase {
         return super.loadClass(name);
       }
     });
+    ClassModel model;
     try {
       model = new Generator().generateClass(clazz, rest);
     } finally {

--- a/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
@@ -563,8 +563,8 @@ public class ClassNullableTest extends ClassTestBase {
   }
 
   private void generateClass(Consumer<ClassModel> test, Class<?> clazz, Class<?>... rest) throws Exception {
-//    ClassModel model = new Generator().generateClass(clazz);
-//    test.accept(model);
+    ClassModel model = new Generator().generateClass(clazz);
+    test.accept(model);
     blacklist(clazz, rest, () -> {
       try {
         test.accept(new Generator().generateClass(clazz, rest));

--- a/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassNullableTest.java
@@ -326,7 +326,7 @@ public class ClassNullableTest extends ClassTestBase {
       assertEquals(1, methods.size());
       MethodInfo mi1 = methods.get(0);
       checkMethod(mi1, "method", 1, "void", MethodKind.HANDLER);
-      assertTrue(mi1.getParams().get(0).isNullableCallback());
+      assertFalse(mi1.getParams().get(0).isNullableCallback());
     }, MethodWithNullableNonAnnotatedTypeVariableHandler.class);
   }
 
@@ -359,7 +359,7 @@ public class ClassNullableTest extends ClassTestBase {
       assertEquals(1, methods.size());
       MethodInfo mi1 = methods.get(0);
       checkMethod(mi1, "method", 1, "void", MethodKind.FUTURE);
-      assertTrue(mi1.getParams().get(0).isNullableCallback());
+      assertFalse(mi1.getParams().get(0).isNullableCallback());
     }, MethodWithNullableNonAnnotatedTypeVariableHandlerAsyncResult.class);
   }
 

--- a/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithCovariantNullableReturn.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithCovariantNullableReturn.java
@@ -1,0 +1,13 @@
+package io.vertx.test.codegen.testapi.nullable;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithCovariantNullableReturn<T> extends MethodWithNullableReturn {
+
+  MethodWithCovariantNullableReturn<String> exceptionHandler();
+
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableInheritedParams.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableInheritedParams.java
@@ -1,0 +1,17 @@
+package io.vertx.test.codegen.testapi.nullable;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithNullableInheritedParams extends MethodWithNullableParams {
+
+  @Override
+  void m(String s, List<String> t, Handler<AsyncResult<String>> u);
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableParams.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableParams.java
@@ -1,15 +1,18 @@
 package io.vertx.test.codegen.testapi.nullable;
 
-import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+import java.util.List;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen
-public interface MethodWithNullableReturn {
+public interface MethodWithNullableParams {
 
-  @Nullable MethodWithNullableReturn exceptionHandler();
+  void m(@Nullable String s, List<@Nullable String> t, Handler<AsyncResult<@Nullable String>> u);
 
 }

--- a/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableReturns.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableReturns.java
@@ -1,0 +1,75 @@
+package io.vertx.test.codegen.testapi.nullable;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.testmodel.TestDataObject;
+import io.vertx.codegen.testmodel.TestEnum;
+import io.vertx.codegen.testmodel.TestGenEnum;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.codegen.testapi.VertxGenClass1;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithNullableReturns {
+
+  @Nullable Byte nullableByteReturn();
+  @Nullable Short nullableShortReturn();
+  @Nullable Integer nullableIntegerReturn();
+  @Nullable Long nullableLongReturn();
+  @Nullable Float nullableFloatReturn();
+  @Nullable Double nullableDoubleReturn();
+  @Nullable Character nullableCharacterReturn();
+  @Nullable String nullableStringReturn();
+  @Nullable JsonObject nullableJsonObjectReturn();
+  @Nullable JsonArray nullableJsonArrayReturn();
+  <T> @Nullable T nullableTypeVariableReturn();
+  @Nullable TestEnum nullableEnumReturn();
+  @Nullable TestDataObject nullableDataObjectReturn();
+  @Nullable VertxGenClass1 nullableApiReturn();
+
+  @Nullable List<Byte> nullableListByteReturn();
+  @Nullable List<Short> nullableListShortReturn();
+  @Nullable List<Integer> nullableListIntegerReturn();
+  @Nullable List<Long> nullableListLongReturn();
+  @Nullable List<Float> nullableListFloatReturn();
+  @Nullable List<Double> nullableListDoubleReturn();
+  @Nullable List<Character> nullableListCharacterReturn();
+  @Nullable List<String> nullableListStringReturn();
+  @Nullable List<JsonObject> nullableListJsonObjectReturn();
+  @Nullable List<JsonArray> nullableListJsonArrayReturn();
+  @Nullable List<TestEnum> nullableListEnumReturn();
+  @Nullable List<TestDataObject> nullableListDataObjectReturn();
+  @Nullable List<VertxGenClass1> nullableListApiReturn();
+
+  @Nullable Set<Byte> nullableSetByteReturn();
+  @Nullable Set<Short> nullableSetShortReturn();
+  @Nullable Set<Integer> nullableSetIntegerReturn();
+  @Nullable Set<Long> nullableSetLongReturn();
+  @Nullable Set<Float> nullableSetFloatReturn();
+  @Nullable Set<Double> nullableSetDoubleReturn();
+  @Nullable Set<Character> nullableSetCharacterReturn();
+  @Nullable Set<String> nullableSetStringReturn();
+  @Nullable Set<JsonObject> nullableSetJsonObjectReturn();
+  @Nullable Set<JsonArray> nullableSetJsonArrayReturn();
+  @Nullable Set<TestEnum> nullableSetEnumReturn();
+  @Nullable Set<TestDataObject> nullableSetDataObjectReturn();
+  @Nullable Set<VertxGenClass1> nullableSetApiReturn();
+
+  @Nullable Map<String, Byte> nullableMapByteReturn();
+  @Nullable Map<String, Short> nullableMapShortReturn();
+  @Nullable Map<String, Integer> nullableMapIntegerReturn();
+  @Nullable Map<String, Long> nullableMapLongReturn();
+  @Nullable Map<String, Float> nullableMapFloatReturn();
+  @Nullable Map<String, Double> nullableMapDoubleReturn();
+  @Nullable Map<String, Character> nullableMapCharacterReturn();
+  @Nullable Map<String, String> nullableMapStringReturn();
+  @Nullable Map<String, JsonObject> nullableMapJsonObjectReturn();
+  @Nullable Map<String, JsonArray> nullableMapJsonArrayReturn();
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableStringHandlerAsyncResult.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/nullable/MethodWithNullableStringHandlerAsyncResult.java
@@ -1,0 +1,16 @@
+package io.vertx.test.codegen.testapi.nullable;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithNullableStringHandlerAsyncResult {
+
+  void method(Handler<AsyncResult<@Nullable String>> s);
+
+}


### PR DESCRIPTION
This PR provides support for obtaining better `@Nullable` information in codegen types. The current support relies on the `javax.lang.model` which is not complete and fails to obtain the annotation with parameterized types (e.g `Handler<AsyncResult<@Nullable String>>`). This is not really a bug but rather an incomplete implementation of the API that is implemented in Java 9.

This PR relies on internal types of the compiler to extract the relevant information. As this is Java 8 specific, the implementation falls back on the `javax.lang.model` API when the internal API is not available and therefore should work with Java 9. When Java 9 will be released we will make sure it works as expected. Note this is not a runtime issue but rather a codegen compile time issue to address.