### PR TITLE
Add ability to use one generator for multiple kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A code generator consist of an _MVEL_ template declared in a `codegen.json` desc
 - `filename` is an _MVEL_ expression for the file name, returning null skips the generation.
 - `templateFilename` is the name of the _MVEL_ template to apply
 - `incremental` true when the template performs incremental processing, false or absent otherwise
-- `kind`: there are several kinds of generators for different use cases
+- `kind`: contains a comma separated list of generator kinds this generator should be used for, there are several kinds of generators for different use cases
     - `class` : applied on each API classes
     - `package` : applied on each Java package
     - `module` : applied on each declared module, a module uniquely identifies an API

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A code generator consist of an _MVEL_ template declared in a `codegen.json` desc
 - `filename` is an _MVEL_ expression for the file name, returning null skips the generation.
 - `templateFilename` is the name of the _MVEL_ template to apply
 - `incremental` true when the template performs incremental processing, false or absent otherwise
-- `kind`: contains a comma separated list of generator kinds this generator should be used for, there are several kinds of generators for different use cases
+- `kind`: can be a String or an Array of Strings each representing a generator type. There are several kinds of generators for different use cases:
     - `class` : applied on each API classes
     - `package` : applied on each Java package
     - `module` : applied on each declared module, a module uniquely identifies an API

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
               <additionalClasspathElement>${project.basedir}/src/test/testgen3</additionalClasspathElement>
               <additionalClasspathElement>${project.basedir}/src/test/testgen4</additionalClasspathElement>
               <additionalClasspathElement>${project.basedir}/src/test/testgen5</additionalClasspathElement>
+              <additionalClasspathElement>${project.basedir}/src/test/testgen6</additionalClasspathElement>
             </additionalClasspathElements>
           </configuration>
         </plugin>

--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -117,10 +117,12 @@ public class CodeGenProcessor extends AbstractProcessor {
         String name = obj.get("name").asText();
         ArrayNode generatorsCfg = (ArrayNode) obj.get("generators");
         for (JsonNode generator : generatorsCfg) {
-          String kindString = generator.get("kind").asText();
           Set<String> kinds = new HashSet<>();
-          for (String kind : kindString.split(",")) {
-            kinds.add(kind.trim());
+          if(generator.get("kind").isArray()) {
+            generator.get("kind").forEach(v -> kinds.add(v.asText()));
+          }
+          else {
+            kinds.add(generator.get("kind").asText());
           }
           JsonNode templateFilenameNode = generator.get("templateFilename");
           if (templateFilenameNode == null) {

--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -94,9 +94,7 @@ public class CodeGenProcessor extends AbstractProcessor {
         .map(Pattern::compile)
         .collect(Collectors.toList());
       return cg -> wanted.stream()
-        .filter(p -> p.matcher(cg.name).matches())
-        .findFirst()
-        .isPresent();
+        .anyMatch(p -> p.matcher(cg.name).matches());
     } else {
       return null;
     }

--- a/src/main/java/io/vertx/codegen/CodeGenProcessor.java
+++ b/src/main/java/io/vertx/codegen/CodeGenProcessor.java
@@ -119,7 +119,11 @@ public class CodeGenProcessor extends AbstractProcessor {
         String name = obj.get("name").asText();
         ArrayNode generatorsCfg = (ArrayNode) obj.get("generators");
         for (JsonNode generator : generatorsCfg) {
-          String kind = generator.get("kind").asText();
+          String kindString = generator.get("kind").asText();
+          Set<String> kinds = new HashSet<>();
+          for (String kind : kindString.split(",")) {
+            kinds.add(kind.trim());
+          }
           JsonNode templateFilenameNode = generator.get("templateFilename");
           if (templateFilenameNode == null) {
             templateFilenameNode = generator.get("templateFileName");
@@ -133,7 +137,7 @@ public class CodeGenProcessor extends AbstractProcessor {
           boolean incremental = generator.has("incremental") && generator.get("incremental").asBoolean();
           if (!templates.contains(templateFilename)) {
             templates.add(templateFilename);
-            generators.add(new CodeGenerator(name, kind, incremental, filename, templateFilename));
+            generators.add(new CodeGenerator(name, kinds, incremental, filename, templateFilename));
           }
         }
       } catch (Exception e) {
@@ -216,7 +220,7 @@ public class CodeGenProcessor extends AbstractProcessor {
             vars.putAll(Case.vars());
             for (CodeGenerator codeGenerator : codeGenerators) {
               vars.putAll(TypeNameTranslator.vars(codeGenerator.name));
-              if (codeGenerator.kind.equals(model.getKind())) {
+              if (codeGenerator.kind.contains(model.getKind())) {
                 String relativeName = (String) MVEL.executeExpression(codeGenerator.filenameExpr, vars);
                 if (relativeName != null) {
 

--- a/src/main/java/io/vertx/codegen/CodeGenerator.java
+++ b/src/main/java/io/vertx/codegen/CodeGenerator.java
@@ -1,13 +1,14 @@
 package io.vertx.codegen;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class CodeGenerator {
   public final String name;
-  public final String kind;
+  public final Set<String> kind;
   public final boolean incremental;
   public final String filename;
   public final String templateFilename;
@@ -16,7 +17,7 @@ public class CodeGenerator {
 
   public CodeGenerator(
     String name,
-    String kind,
+    Set<String> kind,
     boolean incremental,
     String filename,
     String templateFilename) {

--- a/src/test/java/io/vertx/test/codegen/CodeGeneratorTest.java
+++ b/src/test/java/io/vertx/test/codegen/CodeGeneratorTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.test.codegen.testapi.MethodWithValidVertxGenParams;
 import io.vertx.test.codegen.testapi.VertxGenClass1;
 import io.vertx.test.codegen.testapi.VertxGenClass2;
+import io.vertx.test.codegen.testdataobject.CommentedDataObject;
 import io.vertx.test.codegen.testdataobject.PropertyGettersSetters;
 import io.vertx.test.codegen.testenum.ValidEnum;
 import io.vertx.test.codegen.testmodule.modulescoped.ModuleScopedApi;
@@ -22,11 +23,7 @@ import java.io.FileInputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.*;
@@ -241,5 +238,26 @@ public class CodeGeneratorTest {
     File f = new File(testDir, "foo/bar/io/vertx/test/codegen/testapi/MethodWithValidVertxGenParams_Other.java".replace('/', File.separatorChar));
     assertTrue(f.exists());
     assertTrue(f.isFile());
+  }
+
+  @Test
+  public void testMultipleTypes() throws Exception {
+    Compiler compiler = new Compiler(new CodeGenProcessor());
+    compiler.addOption("-Acodegen.generators=testgen6");
+    compiler.addOption("-Acodegen.output=" + testDir.getAbsolutePath());
+    compiler.addOption("-Acodegen.output.testgen6=foo/bar");
+    assertTrue(compiler.compile(CommentedDataObject.class, VertxGenClass1.class, VertxGenClass2.class));
+    File f = new File(testDir, "resource/result.txt".replace('/', File.separatorChar));
+    assertTrue(f.exists());
+    assertTrue(f.isFile());
+    Scanner s = new Scanner(f);
+    Set<String> fileContent = new HashSet<>();
+    while (s.hasNext()){
+      fileContent.add(s.next());
+    }
+    s.close();
+    assertTrue(fileContent.contains(CommentedDataObject.class.getSimpleName()));
+    assertTrue(fileContent.contains(VertxGenClass1.class.getSimpleName()));
+    assertTrue(fileContent.contains(VertxGenClass2.class.getSimpleName()));
   }
 }

--- a/src/test/testgen6/codegen.json
+++ b/src/test/testgen6/codegen.json
@@ -1,0 +1,9 @@
+{
+  "name": "testgen6",
+  "generators": [{
+    "kind": "class,dataObject",
+    "incremental": true,
+    "filename": "'resource/result.txt'",
+    "templateFilename": "templates/multiple_types.templ"
+  }]
+}

--- a/src/test/testgen6/codegen.json
+++ b/src/test/testgen6/codegen.json
@@ -1,7 +1,7 @@
 {
   "name": "testgen6",
   "generators": [{
-    "kind": "class,dataObject",
+    "kind": ["class","dataObject"],
     "incremental": true,
     "filename": "'resource/result.txt'",
     "templateFilename": "templates/multiple_types.templ"

--- a/src/test/testgen6/templates/multiple_types.templ
+++ b/src/test/testgen6/templates/multiple_types.templ
@@ -1,0 +1,1 @@
+@{type.simpleName}\n


### PR DESCRIPTION
A generator definiton should allow multiple types to be matched against the same generator.
This would allow to have the same template be used for classes and dataobjects and, combined with incremental, to collect everything in one resulting file (e.g. a Scala package object)