### PR TITLE
Expose the referenced enums to the template so it can be used during …

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ are referenced from the current interface
 * `abstractSuperTypes` - subset of `superTypes` which are *abstract*
 * `methodMap` - this is a Map<String, MethodInfo> - which allows you to look up all methods with a given name
 * `importedTypes`- this is a `Set<TypeInfo>` containing the types used by this class
+* `referencedDataObjectTypes`- this is a `Set<TypeInfo>` containing the `DataObject` types used by this class
+* `referencedEnumTypes`- this is a `Set<TypeInfo>` containing the `Enum` types used by this class
 
 The `TypeInfo` represents a Java type:
 

--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -70,6 +70,7 @@ public class ClassModel implements Model {
   protected Set<ClassTypeInfo> importedTypes = new HashSet<>();
   protected Set<ApiTypeInfo> referencedTypes = new HashSet<>();
   protected Set<ClassTypeInfo> referencedDataObjectTypes = new HashSet<>();
+  protected Set<EnumTypeInfo> referencedEnumTypes = new HashSet<>();
   protected boolean concrete;
   protected ClassTypeInfo type;
   protected String ifaceSimpleName;
@@ -163,6 +164,13 @@ public class ClassModel implements Model {
    */
   public Set<ClassTypeInfo> getReferencedDataObjectTypes() {
     return referencedDataObjectTypes;
+  }
+
+  /**
+   * @return all the referenced data object types
+   */
+  public Set<EnumTypeInfo> getReferencedEnumTypes() {
+    return referencedEnumTypes;
   }
 
   public String getIfaceSimpleName() {
@@ -522,6 +530,11 @@ public class ClassModel implements Model {
         flatMap(Helper.instanceOf(ClassTypeInfo.class)).
         filter(t -> t.getKind() == ClassKind.DATA_OBJECT).
         forEach(referencedDataObjectTypes::add);
+    collectedTypes.stream().
+      map(ClassTypeInfo::getRaw).
+      flatMap(Helper.instanceOf(EnumTypeInfo.class)).
+      filter(t -> t.getKind() == ClassKind.ENUM).
+      forEach(referencedEnumTypes::add);
   }
 
   boolean process() {
@@ -950,6 +963,7 @@ public class ClassModel implements Model {
     vars.put("classAnnotations", getAnnotations());
     vars.put("annotationsByMethodName", getMethodAnnotations());
     vars.put("referencedDataObjectTypes", getReferencedDataObjectTypes());
+    vars.put("referencedEnumTypes", getReferencedEnumTypes());
     vars.put("typeParams", getTypeParams());
     vars.put("instanceMethods", getInstanceMethods());
     vars.put("staticMethods", getStaticMethods());

--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -515,26 +515,29 @@ public class ClassModel implements Model {
   }
 
   private void determineApiTypes() {
-    collectedTypes.stream().
+    importedTypes = collectedTypes.stream().
         map(ClassTypeInfo::getRaw).
         flatMap(Helper.instanceOf(ClassTypeInfo.class)).
         filter(t -> !t.getPackageName().equals(ifaceFQCN)).
-        forEach(importedTypes::add);
-    collectedTypes.stream().
+        collect(Collectors.toSet());
+
+    referencedTypes = collectedTypes.stream().
         map(ClassTypeInfo::getRaw).
         flatMap(Helper.instanceOf(ApiTypeInfo.class)).
         filter(t -> !t.equals(type.getRaw())).
-        forEach(referencedTypes::add);
-    collectedTypes.stream().
+        collect(Collectors.toSet());
+
+    referencedDataObjectTypes = collectedTypes.stream().
         map(ClassTypeInfo::getRaw).
         flatMap(Helper.instanceOf(ClassTypeInfo.class)).
         filter(t -> t.getKind() == ClassKind.DATA_OBJECT).
-        forEach(referencedDataObjectTypes::add);
-    collectedTypes.stream().
+        collect(Collectors.toSet());
+
+    referencedEnumTypes = collectedTypes.stream().
       map(ClassTypeInfo::getRaw).
       flatMap(Helper.instanceOf(EnumTypeInfo.class)).
       filter(t -> t.getKind() == ClassKind.ENUM).
-      forEach(referencedEnumTypes::add);
+      collect(Collectors.toSet());
   }
 
   boolean process() {

--- a/src/test/java/io/vertx/test/codegen/EnumTest.java
+++ b/src/test/java/io/vertx/test/codegen/EnumTest.java
@@ -1,9 +1,9 @@
 package io.vertx.test.codegen;
 
-import io.vertx.codegen.EnumModel;
-import io.vertx.codegen.EnumValueInfo;
-import io.vertx.codegen.GenException;
-import io.vertx.codegen.Generator;
+import io.vertx.codegen.*;
+import io.vertx.codegen.type.EnumTypeInfo;
+import io.vertx.codegen.type.TypeInfo;
+import io.vertx.test.codegen.testenum.EnumAsParam;
 import io.vertx.test.codegen.testenum.InvalidEmptyEnum;
 import io.vertx.test.codegen.testenum.ValidEnum;
 import org.junit.Test;
@@ -41,5 +41,14 @@ public class EnumTest {
       fail();
     } catch (GenException ignore) {
     }
+  }
+
+  @Test
+  public void testEnumListingFromApi() throws Exception {
+    ClassModel model = new Generator().generateClass(EnumAsParam.class);
+    assertTrue(model.getReferencedEnumTypes().size() > 0);
+    TypeInfo typeInfo = (TypeInfo) model.getReferencedEnumTypes().toArray()[0];
+    assertTrue(typeInfo instanceof EnumTypeInfo);
+    assertEquals("ValidEnum", typeInfo.getSimpleName());
   }
 }

--- a/src/test/java/io/vertx/test/codegen/testenum/EnumAsParam.java
+++ b/src/test/java/io/vertx/test/codegen/testenum/EnumAsParam.java
@@ -1,0 +1,9 @@
+package io.vertx.test.codegen.testenum;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface EnumAsParam {
+
+  void callMe(ValidEnum e);
+}


### PR DESCRIPTION
…generation

The use case for this is when generating code that relies on enums there was no easy way to identify which enum are referenced.