### PR TITLE
WIP - #161 Preparing handling of TypeInternal via MR JAR

### DIFF
--- a/src/main/java/io/vertx/codegen/type/MirrorTypeInternal.java
+++ b/src/main/java/io/vertx/codegen/type/MirrorTypeInternal.java
@@ -1,0 +1,61 @@
+package io.vertx.codegen.type;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import io.vertx.codegen.type.TypeUse.TypeInternal;
+
+class MirrorTypeInternal implements TypeInternal {
+
+  public static final TypeUse.TypeInternalProvider PROVIDER = new TypeUse.TypeInternalProvider() {
+    @Override
+    public TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int index) {
+      return new MirrorTypeInternal(methodElt.getParameters().get(index).asType());
+    }
+
+    @Override
+    public TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt) {
+      return new MirrorTypeInternal(methodElt.getReturnType());
+    }
+  };
+
+  final TypeMirror mirror;
+
+  MirrorTypeInternal(TypeMirror mirror) {
+    this.mirror = mirror;
+  }
+
+  @Override
+  public String rawName() {
+    if (mirror.getKind() == TypeKind.DECLARED) {
+      return ((TypeElement)((DeclaredType)mirror).asElement()).getQualifiedName().toString();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean isNullable() {
+    for (AnnotationMirror annotation : mirror.getAnnotationMirrors()) {
+      DeclaredType annotationType = annotation.getAnnotationType();
+      TypeElement annotationTypeElt = (TypeElement) annotationType.asElement();
+      if (annotationTypeElt.getQualifiedName().toString().equals(TypeUse.NULLABLE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public TypeInternal getArgAt(int index) {
+    List<? extends TypeMirror> args = ((DeclaredType) mirror).getTypeArguments();
+    return new MirrorTypeInternal(args.get(index));
+  }
+}

--- a/src/main/java/io/vertx/codegen/type/ReflectTypeInternal.java
+++ b/src/main/java/io/vertx/codegen/type/ReflectTypeInternal.java
@@ -1,0 +1,83 @@
+package io.vertx.codegen.type;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+
+import io.vertx.codegen.Helper;
+import io.vertx.codegen.type.TypeUse.TypeInternal;
+
+class ReflectTypeInternal implements TypeInternal {
+
+  public static final TypeUse.TypeInternalProvider PROVIDER = new TypeUse.TypeInternalProvider() {
+    private Method getMethod(ProcessingEnvironment env, ExecutableElement methodElt) {
+      Method methodRef = Helper.getReflectMethod(Thread.currentThread().getContextClassLoader(), methodElt);
+      if (methodRef == null) {
+        methodRef = Helper.getReflectMethod(env, methodElt);
+      }
+      return methodRef;
+    }
+
+    @Override
+    public TypeUse.TypeInternal forParam(ProcessingEnvironment env, ExecutableElement methodElt, int paramIndex) {
+      Method methodRef = getMethod(env, methodElt);
+      if (methodRef == null) {
+        return null;
+      }
+      AnnotatedType annotated = methodRef.getAnnotatedParameterTypes()[paramIndex];
+      return new ReflectTypeInternal(annotated);
+    }
+
+    @Override
+    public TypeUse.TypeInternal forReturn(ProcessingEnvironment env, ExecutableElement methodElt) {
+      Method methodRef = getMethod(env, methodElt);
+      if (methodRef == null) {
+        return null;
+      }
+      AnnotatedType annotated = methodRef.getAnnotatedReturnType();
+      return new ReflectTypeInternal(annotated);
+    }
+  };
+
+  private final AnnotatedType annotatedType;
+  private final boolean nullable;
+
+  private ReflectTypeInternal(AnnotatedType annotated) {
+    this.annotatedType = annotated;
+    this.nullable = isNullable(annotated);
+  }
+
+  @Override
+  public String rawName() {
+    if (annotatedType instanceof AnnotatedParameterizedType) {
+      return ((ParameterizedType)(annotatedType.getType())).getRawType().getTypeName();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean isNullable() {
+    return nullable;
+  }
+
+  @Override
+  public TypeInternal getArgAt(int index) {
+    AnnotatedParameterizedType annotatedParameterizedType = (AnnotatedParameterizedType) annotatedType;
+    return new ReflectTypeInternal(annotatedParameterizedType.getAnnotatedActualTypeArguments()[index]);
+  }
+
+  private static boolean isNullable(AnnotatedType type) {
+    for (Annotation annotation : type.getAnnotations()) {
+      if (annotation.annotationType().getName().equals(TypeUse.NULLABLE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/io/vertx/codegen/type/TypeInternalProviders.java
+++ b/src/main/java/io/vertx/codegen/type/TypeInternalProviders.java
@@ -1,0 +1,25 @@
+package io.vertx.codegen.type;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.vertx.codegen.type.TypeUse.TypeInternalProvider;
+
+/**
+ * Catalog of available {@link TypeInternalProvider}s.
+ *
+ * @author Gunnar Morling
+ */
+public class TypeInternalProviders {
+
+  /**
+   * Returns an immutable list of the type internal providers to be applied.
+   */
+  public static List<TypeInternalProvider> getProviders() {
+    return Arrays.asList(
+      TreeTypeInternal.PROVIDER,
+      ReflectTypeInternal.PROVIDER,
+      MirrorTypeInternal.PROVIDER
+    );
+  }
+}

--- a/src/main/java9/io/vertx/codegen/type/TypeInternalProviders.java
+++ b/src/main/java9/io/vertx/codegen/type/TypeInternalProviders.java
@@ -1,0 +1,24 @@
+package io.vertx.codegen.type;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.vertx.codegen.type.TypeUse.TypeInternalProvider;
+
+/**
+ * Catalog of available {@link TypeInternalProvider}s.
+ *
+ * @author Gunnar Morling
+ */
+public class TypeInternalProviders {
+
+  /**
+   * Returns an immutable list of the type internal providers to be applied.
+   */
+  public static List<TypeInternalProvider> getProviders() {
+    return Arrays.asList(
+      ReflectTypeInternal.PROVIDER,
+      MirrorTypeInternal.PROVIDER
+    );
+  }
+}


### PR DESCRIPTION
Hey @vietj, that's how you could handle the issue around `TreeTypeInternal` (if I understand things correctly). This adds a new source folder, _src/main/java9_ and moves the existing `MirrorTypeInternal` there. The previous `TreeTypeInternal` is renamed to `MirrorTypeInternal` and remains under _src/main/java_.

The next step is to put an MR JAR build in place. This should put the tree API based implementation under _io/vert.x/codegen/type/MirrorTypeInternal.class_ and the mirror-based one under _META-INF/versions/9/io/vert.x/codegen/type/MirrorTypeInternal.class_ in the resulting JAR.

The code in `TypeUse` can just invoke `MirrorTypeInternal.PROVIDER`, and the right version of `MirrorTypeInternal` should be linked in, based on the version of the Java runtime this is executed. I.e. you don't need to perform that reflection based check yourself, the runtime is enabling the right flavor of the class automatically for you.