### PR TITLE
add deprecated info and test

### DIFF
--- a/src/main/java/io/vertx/codegen/MethodInfo.java
+++ b/src/main/java/io/vertx/codegen/MethodInfo.java
@@ -49,11 +49,12 @@ public class MethodInfo implements Comparable<MethodInfo> {
   List<TypeParamInfo.Method> typeParams;
   LinkedHashSet<ClassTypeInfo> ownerTypes;
   List<ParamInfo> params;
+  boolean deprecated;
 
   public MethodInfo(Set<ClassTypeInfo> ownerTypes, String name, MethodKind kind,
                     TypeInfo returnType, Text returnDescription, boolean fluent,  boolean cacheReturn,
                     List<ParamInfo> params, String comment, Doc doc, boolean staticMethod, boolean defaultMethod,
-                    List<TypeParamInfo.Method> typeParams) {
+                    List<TypeParamInfo.Method> typeParams, boolean deprecated) {
 
 
     this.comment = comment;
@@ -69,6 +70,7 @@ public class MethodInfo implements Comparable<MethodInfo> {
     this.params = params;
     this.typeParams = typeParams;
     this.ownerTypes = new LinkedHashSet<>(ownerTypes);
+    this.deprecated = deprecated;
   }
 
   public String getName() {
@@ -204,6 +206,10 @@ public class MethodInfo implements Comparable<MethodInfo> {
 
   public boolean isDefaultMethod() {
     return defaultMethod;
+  }
+
+  public boolean isDeprecated() {
+    return deprecated;
   }
 
   public List<TypeParamInfo.Method> getTypeParams() {

--- a/src/main/java/io/vertx/codegen/ProxyMethodInfo.java
+++ b/src/main/java/io/vertx/codegen/ProxyMethodInfo.java
@@ -34,10 +34,10 @@ public class ProxyMethodInfo extends MethodInfo {
 
   public ProxyMethodInfo(Set<ClassTypeInfo> ownerTypes, String name, MethodKind kind, TypeInfo returnType, Text returnDescription, boolean fluent,
                          boolean cacheReturn, List<ParamInfo> params, String comment, Doc doc, boolean staticMethod, boolean defaultMethod,
-                         List<TypeParamInfo.Method> typeParams, boolean proxyIgnore, boolean proxyClose) {
+                         List<TypeParamInfo.Method> typeParams, boolean proxyIgnore, boolean proxyClose, boolean deprecated) {
 
 
-    super(ownerTypes, name, kind, returnType, returnDescription, fluent, cacheReturn, params, comment, doc, staticMethod, defaultMethod, typeParams);
+    super(ownerTypes, name, kind, returnType, returnDescription, fluent, cacheReturn, params, comment, doc, staticMethod, defaultMethod, typeParams, deprecated);
     this.proxyIgnore = proxyIgnore;
     this.proxyClose = proxyClose;
   }

--- a/src/main/java/io/vertx/codegen/ProxyModel.java
+++ b/src/main/java/io/vertx/codegen/ProxyModel.java
@@ -117,7 +117,7 @@ public class ProxyModel extends ClassModel {
                                         Text returnDescription,
                                         boolean isFluent, boolean isCacheReturn, List<ParamInfo> mParams,
                                         ExecutableElement methodElt, boolean isStatic, boolean isDefault, ArrayList<TypeParamInfo.Method> typeParams,
-                                        TypeElement declaringElt) {
+                                        TypeElement declaringElt, boolean methodDeprecated) {
     AnnotationMirror proxyIgnoreAnnotation = Helper.resolveMethodAnnotation(ProxyIgnore.class, elementUtils, typeUtils, declaringElt, methodElt);
     boolean isProxyIgnore = proxyIgnoreAnnotation != null;
     AnnotationMirror proxyCloseAnnotation = Helper.resolveMethodAnnotation(ProxyClose.class, elementUtils, typeUtils, declaringElt, methodElt);
@@ -138,7 +138,7 @@ public class ProxyModel extends ClassModel {
     }
     return new ProxyMethodInfo(ownerTypes, methodName, kind, returnType, returnDescription,
       isFluent, isCacheReturn, mParams, comment, doc, isStatic, isDefault, typeParams, isProxyIgnore,
-      isProxyClose);
+      isProxyClose, methodDeprecated);
   }
 
   private boolean isLegalHandlerAsyncResultType(TypeInfo type) {

--- a/src/test/java/io/vertx/test/codegen/DeprecatedTest.java
+++ b/src/test/java/io/vertx/test/codegen/DeprecatedTest.java
@@ -1,0 +1,42 @@
+package io.vertx.test.codegen;
+
+import io.vertx.codegen.ClassModel;
+import io.vertx.codegen.Generator;
+import io.vertx.codegen.ProxyModel;
+import io.vertx.test.codegen.proxytestapi.ValidProxyCloseWithFuture;
+import io.vertx.test.codegen.testapi.DeprecatedInterface;
+import io.vertx.test.codegen.testapi.GenericInterface;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DeprecatedTest {
+  private Generator generator = new Generator();
+  @Test
+  public void testVertxGenDeprecated() throws Exception {
+    ClassModel model = generator.generateClass(DeprecatedInterface.class);
+    assertTrue(model.isDeprecated());
+    assertEquals(model.getVars().get("deprecated"), true);
+    assertTrue(model.getMethods().get(0).isDeprecated());
+  }
+  @Test
+  public void testProxyGenDeprecated() throws Exception {
+    ProxyModel model = generator.generateProxyModel(DeprecatedInterface.class);
+    assertTrue(model.isDeprecated());
+    assertEquals(model.getVars().get("deprecated"), true);
+    assertTrue(model.getMethods().get(0).isDeprecated());
+  }
+  @Test
+  public void testVertxGenNotDeprecated() throws Exception {
+    ClassModel model = generator.generateClass(GenericInterface.class);
+    assertFalse(model.isDeprecated());
+    assertEquals(model.getVars().get("deprecated"), false);
+    assertFalse(model.getMethods().get(0).isDeprecated());
+  }
+  @Test
+  public void testProxyGenNotDeprecated() throws Exception {
+    ProxyModel model = generator.generateProxyModel(ValidProxyCloseWithFuture.class);
+    assertFalse(model.isDeprecated());
+    assertEquals(model.getVars().get("deprecated"), false);
+    assertFalse(model.getMethods().get(0).isDeprecated());
+  }
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/DeprecatedInterface.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/DeprecatedInterface.java
@@ -1,0 +1,12 @@
+package io.vertx.test.codegen.testapi;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+@ProxyGen
+@Deprecated
+public interface DeprecatedInterface {
+  @Deprecated
+  void test();
+}


### PR DESCRIPTION
I added a field  ‘deprecated’ for `ClassModel` and `Methodinfo`, aiming to make convenient for other languages to add additional infomations.
