### PR TITLE
Add equals & hashCode helper methods for DataObjectConverter

### DIFF
--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -68,6 +68,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.println("        if (lhs == rhs) return true;");
     writer.println("        return ");
     String equalsString = model.getPropertyMap().values().stream()
+      .filter(prop -> Objects.nonNull(prop.getGetterMethod()))
       .map(prop -> String.format("            Objects.equals(lhs.%s(), rhs.%s())", prop.getGetterMethod(), prop.getGetterMethod()))
       .collect(Collectors.joining(" &&\n"));
     writer.println(equalsString + ";");
@@ -78,6 +79,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     String simpleName = model.getType().getSimpleName();
     writer.println(String.format("    public static int hashCode(%s o) {", simpleName));
     String equalsString = model.getPropertyMap().values().stream()
+      .filter(prop -> Objects.nonNull(prop.getGetterMethod()))
       .map(prop -> String.format("                o.%s()", prop.getGetterMethod()))
       .collect(Collectors.joining(",\n"));
     writer.println(String.format("        return Objects.hash(\n%s);", equalsString));

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -65,12 +65,15 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
   private void generateEquals(DataObjectModel model, PrintWriter writer) {
     String simpleName = model.getType().getSimpleName();
     writer.println(String.format("    public static boolean equals(%s lhs, %s rhs) {", simpleName, simpleName));
-    writer.println("        if (lhs == rhs) return true;");
-    writer.println("        return ");
+    writer.println("        if (lhs == rhs) {");
+    writer.println("          return true;");
+    writer.println("        }");
+    writer.println("");
+    writer.print("        return ");
     String equalsString = model.getPropertyMap().values().stream()
       .filter(prop -> Objects.nonNull(prop.getGetterMethod()))
-      .map(prop -> String.format("            Objects.equals(lhs.%s(), rhs.%s())", prop.getGetterMethod(), prop.getGetterMethod()))
-      .collect(Collectors.joining(" &&\n"));
+      .map(prop -> String.format("Objects.equals(lhs.%s(), rhs.%s())", prop.getGetterMethod(), prop.getGetterMethod()))
+      .collect(Collectors.joining(" &&\n            "));
     writer.println(equalsString + ";");
     writer.println("    }");
   }

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -41,9 +41,11 @@ public class ChildInheritingDataObjectConverter {
   }
 
     public static boolean equals(ChildInheritingDataObject lhs, ChildInheritingDataObject rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
             Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
     }
 

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Objects;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ChildInheritingDataObject}.
@@ -38,4 +39,18 @@ public class ChildInheritingDataObjectConverter {
       json.put("parentProperty", obj.getParentProperty());
     }
   }
+
+    public static boolean equals(ChildInheritingDataObject lhs, ChildInheritingDataObject rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
+            Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+    }
+
+
+    public static int hashCode(ChildInheritingDataObject o) {
+        return Objects.hash(
+                o.getChildProperty(),
+                o.getParentProperty());
+    }
 }

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Objects;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ChildNotInheritingDataObject}.
@@ -30,4 +31,18 @@ public class ChildNotInheritingDataObjectConverter {
       json.put("childProperty", obj.getChildProperty());
     }
   }
+
+    public static boolean equals(ChildNotInheritingDataObject lhs, ChildNotInheritingDataObject rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
+            Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+    }
+
+
+    public static int hashCode(ChildNotInheritingDataObject o) {
+        return Objects.hash(
+                o.getChildProperty(),
+                o.getParentProperty());
+    }
 }

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -33,9 +33,11 @@ public class ChildNotInheritingDataObjectConverter {
   }
 
     public static boolean equals(ChildNotInheritingDataObject lhs, ChildNotInheritingDataObject rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
             Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
     }
 

--- a/src/test/generated/io/vertx/test/codegen/converter/DataObjectWithGenIgnoreConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/DataObjectWithGenIgnoreConverter.java
@@ -1,0 +1,56 @@
+package io.vertx.test.codegen.converter;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.Objects;
+
+/**
+ * Converter for {@link io.vertx.test.codegen.converter.DataObjectWithGenIgnore}.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.test.codegen.converter.DataObjectWithGenIgnore} original class using Vert.x codegen.
+ */
+public class DataObjectWithGenIgnoreConverter {
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithGenIgnore obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+          case "firstName":
+            if (member.getValue() instanceof String) {
+              obj.setFirstName((String)member.getValue());
+            }
+            break;
+          case "lastName":
+            if (member.getValue() instanceof String) {
+              obj.setLastName((String)member.getValue());
+            }
+            break;
+      }
+    }
+  }
+
+  public static void toJson(DataObjectWithGenIgnore obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(DataObjectWithGenIgnore obj, java.util.Map<String, Object> json) {
+    if (obj.getFirstName() != null) {
+      json.put("firstName", obj.getFirstName());
+    }
+    if (obj.getLastName() != null) {
+      json.put("lastName", obj.getLastName());
+    }
+  }
+
+    public static boolean equals(DataObjectWithGenIgnore lhs, DataObjectWithGenIgnore rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getFirstName(), rhs.getFirstName()) &&
+            Objects.equals(lhs.getLastName(), rhs.getLastName());
+    }
+
+
+    public static int hashCode(DataObjectWithGenIgnore o) {
+        return Objects.hash(
+                o.getFirstName(),
+                o.getLastName());
+    }
+}

--- a/src/test/generated/io/vertx/test/codegen/converter/DataObjectWithGenIgnoreConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/DataObjectWithGenIgnoreConverter.java
@@ -41,9 +41,11 @@ public class DataObjectWithGenIgnoreConverter {
   }
 
     public static boolean equals(DataObjectWithGenIgnore lhs, DataObjectWithGenIgnore rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getFirstName(), rhs.getFirstName()) &&
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getFirstName(), rhs.getFirstName()) &&
             Objects.equals(lhs.getLastName(), rhs.getLastName());
     }
 

--- a/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -33,9 +33,11 @@ public class ParentDataObjectConverter {
   }
 
     public static boolean equals(ParentDataObject lhs, ParentDataObject rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
     }
 
 

--- a/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Objects;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ParentDataObject}.
@@ -30,4 +31,16 @@ public class ParentDataObjectConverter {
       json.put("parentProperty", obj.getParentProperty());
     }
   }
+
+    public static boolean equals(ParentDataObject lhs, ParentDataObject rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+    }
+
+
+    public static int hashCode(ParentDataObject o) {
+        return Objects.hash(
+                o.getParentProperty());
+    }
 }

--- a/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -40,9 +40,11 @@ public class SetterAdderDataObjectConverter {
   }
 
     public static boolean equals(SetterAdderDataObject lhs, SetterAdderDataObject rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getValues(), rhs.getValues());
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getValues(), rhs.getValues());
     }
 
 

--- a/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Objects;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.SetterAdderDataObject}.
@@ -37,4 +38,16 @@ public class SetterAdderDataObjectConverter {
       json.put("values", array);
      }
   }
+
+    public static boolean equals(SetterAdderDataObject lhs, SetterAdderDataObject rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getValues(), rhs.getValues());
+    }
+
+
+    public static int hashCode(SetterAdderDataObject o) {
+        return Objects.hash(
+                o.getValues());
+    }
 }

--- a/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -1250,9 +1250,11 @@ public class TestDataObjectConverter {
   }
 
     public static boolean equals(TestDataObject lhs, TestDataObject rhs) {
-        if (lhs == rhs) return true;
-        return 
-            Objects.equals(lhs.getAddedAggregatedDataObjects(), rhs.getAddedAggregatedDataObjects()) &&
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getAddedAggregatedDataObjects(), rhs.getAddedAggregatedDataObjects()) &&
             Objects.equals(lhs.getAddedBoxedBooleanValues(), rhs.getAddedBoxedBooleanValues()) &&
             Objects.equals(lhs.getAddedBoxedByteValues(), rhs.getAddedBoxedByteValues()) &&
             Objects.equals(lhs.getAddedBoxedCharValues(), rhs.getAddedBoxedCharValues()) &&

--- a/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Objects;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.TestDataObject}.
@@ -1247,4 +1248,208 @@ public class TestDataObjectConverter {
       json.put("stringValues", array);
      }
   }
+
+    public static boolean equals(TestDataObject lhs, TestDataObject rhs) {
+        if (lhs == rhs) return true;
+        return 
+            Objects.equals(lhs.getAddedAggregatedDataObjects(), rhs.getAddedAggregatedDataObjects()) &&
+            Objects.equals(lhs.getAddedBoxedBooleanValues(), rhs.getAddedBoxedBooleanValues()) &&
+            Objects.equals(lhs.getAddedBoxedByteValues(), rhs.getAddedBoxedByteValues()) &&
+            Objects.equals(lhs.getAddedBoxedCharValues(), rhs.getAddedBoxedCharValues()) &&
+            Objects.equals(lhs.getAddedBoxedDoubleValues(), rhs.getAddedBoxedDoubleValues()) &&
+            Objects.equals(lhs.getAddedBoxedFloatValues(), rhs.getAddedBoxedFloatValues()) &&
+            Objects.equals(lhs.getAddedBoxedIntValues(), rhs.getAddedBoxedIntValues()) &&
+            Objects.equals(lhs.getAddedBoxedLongValues(), rhs.getAddedBoxedLongValues()) &&
+            Objects.equals(lhs.getAddedBoxedShortValues(), rhs.getAddedBoxedShortValues()) &&
+            Objects.equals(lhs.getAddedBuffers(), rhs.getAddedBuffers()) &&
+            Objects.equals(lhs.getAddedHttpMethods(), rhs.getAddedHttpMethods()) &&
+            Objects.equals(lhs.getAddedJsonArrays(), rhs.getAddedJsonArrays()) &&
+            Objects.equals(lhs.getAddedJsonObjects(), rhs.getAddedJsonObjects()) &&
+            Objects.equals(lhs.getAddedObjects(), rhs.getAddedObjects()) &&
+            Objects.equals(lhs.getAddedStringValues(), rhs.getAddedStringValues()) &&
+            Objects.equals(lhs.getAggregatedDataObject(), rhs.getAggregatedDataObject()) &&
+            Objects.equals(lhs.getAggregatedDataObjectMap(), rhs.getAggregatedDataObjectMap()) &&
+            Objects.equals(lhs.getAggregatedDataObjectSet(), rhs.getAggregatedDataObjectSet()) &&
+            Objects.equals(lhs.getAggregatedDataObjects(), rhs.getAggregatedDataObjects()) &&
+            Objects.equals(lhs.isBooleanValue(), rhs.isBooleanValue()) &&
+            Objects.equals(lhs.getBoxedBooleanSet(), rhs.getBoxedBooleanSet()) &&
+            Objects.equals(lhs.isBoxedBooleanValue(), rhs.isBoxedBooleanValue()) &&
+            Objects.equals(lhs.getBoxedBooleanValueMap(), rhs.getBoxedBooleanValueMap()) &&
+            Objects.equals(lhs.getBoxedBooleanValues(), rhs.getBoxedBooleanValues()) &&
+            Objects.equals(lhs.getBoxedByteSet(), rhs.getBoxedByteSet()) &&
+            Objects.equals(lhs.getBoxedByteValue(), rhs.getBoxedByteValue()) &&
+            Objects.equals(lhs.getBoxedByteValueMap(), rhs.getBoxedByteValueMap()) &&
+            Objects.equals(lhs.getBoxedByteValues(), rhs.getBoxedByteValues()) &&
+            Objects.equals(lhs.getBoxedCharSet(), rhs.getBoxedCharSet()) &&
+            Objects.equals(lhs.getBoxedCharValue(), rhs.getBoxedCharValue()) &&
+            Objects.equals(lhs.getBoxedCharValueMap(), rhs.getBoxedCharValueMap()) &&
+            Objects.equals(lhs.getBoxedCharValues(), rhs.getBoxedCharValues()) &&
+            Objects.equals(lhs.getBoxedDoubleSet(), rhs.getBoxedDoubleSet()) &&
+            Objects.equals(lhs.getBoxedDoubleValue(), rhs.getBoxedDoubleValue()) &&
+            Objects.equals(lhs.getBoxedDoubleValueMap(), rhs.getBoxedDoubleValueMap()) &&
+            Objects.equals(lhs.getBoxedDoubleValues(), rhs.getBoxedDoubleValues()) &&
+            Objects.equals(lhs.getBoxedFloatSet(), rhs.getBoxedFloatSet()) &&
+            Objects.equals(lhs.getBoxedFloatValue(), rhs.getBoxedFloatValue()) &&
+            Objects.equals(lhs.getBoxedFloatValueMap(), rhs.getBoxedFloatValueMap()) &&
+            Objects.equals(lhs.getBoxedFloatValues(), rhs.getBoxedFloatValues()) &&
+            Objects.equals(lhs.getBoxedIntSet(), rhs.getBoxedIntSet()) &&
+            Objects.equals(lhs.getBoxedIntValue(), rhs.getBoxedIntValue()) &&
+            Objects.equals(lhs.getBoxedIntValueMap(), rhs.getBoxedIntValueMap()) &&
+            Objects.equals(lhs.getBoxedIntValues(), rhs.getBoxedIntValues()) &&
+            Objects.equals(lhs.getBoxedLongSet(), rhs.getBoxedLongSet()) &&
+            Objects.equals(lhs.getBoxedLongValue(), rhs.getBoxedLongValue()) &&
+            Objects.equals(lhs.getBoxedLongValueMap(), rhs.getBoxedLongValueMap()) &&
+            Objects.equals(lhs.getBoxedLongValues(), rhs.getBoxedLongValues()) &&
+            Objects.equals(lhs.getBoxedShortSet(), rhs.getBoxedShortSet()) &&
+            Objects.equals(lhs.getBoxedShortValue(), rhs.getBoxedShortValue()) &&
+            Objects.equals(lhs.getBoxedShortValueMap(), rhs.getBoxedShortValueMap()) &&
+            Objects.equals(lhs.getBoxedShortValues(), rhs.getBoxedShortValues()) &&
+            Objects.equals(lhs.getBuffer(), rhs.getBuffer()) &&
+            Objects.equals(lhs.getBufferMap(), rhs.getBufferMap()) &&
+            Objects.equals(lhs.getBufferSet(), rhs.getBufferSet()) &&
+            Objects.equals(lhs.getBuffers(), rhs.getBuffers()) &&
+            Objects.equals(lhs.getByteValue(), rhs.getByteValue()) &&
+            Objects.equals(lhs.getCharValue(), rhs.getCharValue()) &&
+            Objects.equals(lhs.getDoubleValue(), rhs.getDoubleValue()) &&
+            Objects.equals(lhs.getFloatValue(), rhs.getFloatValue()) &&
+            Objects.equals(lhs.getHttpMethod(), rhs.getHttpMethod()) &&
+            Objects.equals(lhs.getHttpMethodMap(), rhs.getHttpMethodMap()) &&
+            Objects.equals(lhs.getHttpMethodSet(), rhs.getHttpMethodSet()) &&
+            Objects.equals(lhs.getHttpMethods(), rhs.getHttpMethods()) &&
+            Objects.equals(lhs.getIntValue(), rhs.getIntValue()) &&
+            Objects.equals(lhs.getJsonArray(), rhs.getJsonArray()) &&
+            Objects.equals(lhs.getJsonArrayMap(), rhs.getJsonArrayMap()) &&
+            Objects.equals(lhs.getJsonArraySet(), rhs.getJsonArraySet()) &&
+            Objects.equals(lhs.getJsonArrays(), rhs.getJsonArrays()) &&
+            Objects.equals(lhs.getJsonObject(), rhs.getJsonObject()) &&
+            Objects.equals(lhs.getJsonObjectMap(), rhs.getJsonObjectMap()) &&
+            Objects.equals(lhs.getJsonObjectSet(), rhs.getJsonObjectSet()) &&
+            Objects.equals(lhs.getJsonObjects(), rhs.getJsonObjects()) &&
+            Objects.equals(lhs.getKeyedBoxedBooleanValues(), rhs.getKeyedBoxedBooleanValues()) &&
+            Objects.equals(lhs.getKeyedBoxedByteValues(), rhs.getKeyedBoxedByteValues()) &&
+            Objects.equals(lhs.getKeyedBoxedCharValues(), rhs.getKeyedBoxedCharValues()) &&
+            Objects.equals(lhs.getKeyedBoxedDoubleValues(), rhs.getKeyedBoxedDoubleValues()) &&
+            Objects.equals(lhs.getKeyedBoxedFloatValues(), rhs.getKeyedBoxedFloatValues()) &&
+            Objects.equals(lhs.getKeyedBoxedIntValues(), rhs.getKeyedBoxedIntValues()) &&
+            Objects.equals(lhs.getKeyedBoxedLongValues(), rhs.getKeyedBoxedLongValues()) &&
+            Objects.equals(lhs.getKeyedBoxedShortValues(), rhs.getKeyedBoxedShortValues()) &&
+            Objects.equals(lhs.getKeyedBufferValues(), rhs.getKeyedBufferValues()) &&
+            Objects.equals(lhs.getKeyedDataObjectValues(), rhs.getKeyedDataObjectValues()) &&
+            Objects.equals(lhs.getKeyedEnumValues(), rhs.getKeyedEnumValues()) &&
+            Objects.equals(lhs.getKeyedJsonArrayValues(), rhs.getKeyedJsonArrayValues()) &&
+            Objects.equals(lhs.getKeyedJsonObjectValues(), rhs.getKeyedJsonObjectValues()) &&
+            Objects.equals(lhs.getKeyedObjectValues(), rhs.getKeyedObjectValues()) &&
+            Objects.equals(lhs.getKeyedStringValues(), rhs.getKeyedStringValues()) &&
+            Objects.equals(lhs.getLongValue(), rhs.getLongValue()) &&
+            Objects.equals(lhs.getObjectMap(), rhs.getObjectMap()) &&
+            Objects.equals(lhs.getObjectSet(), rhs.getObjectSet()) &&
+            Objects.equals(lhs.getObjects(), rhs.getObjects()) &&
+            Objects.equals(lhs.getShortValue(), rhs.getShortValue()) &&
+            Objects.equals(lhs.getStringSet(), rhs.getStringSet()) &&
+            Objects.equals(lhs.getStringValue(), rhs.getStringValue()) &&
+            Objects.equals(lhs.getStringValueMap(), rhs.getStringValueMap()) &&
+            Objects.equals(lhs.getStringValues(), rhs.getStringValues());
+    }
+
+
+    public static int hashCode(TestDataObject o) {
+        return Objects.hash(
+                o.getAddedAggregatedDataObjects(),
+                o.getAddedBoxedBooleanValues(),
+                o.getAddedBoxedByteValues(),
+                o.getAddedBoxedCharValues(),
+                o.getAddedBoxedDoubleValues(),
+                o.getAddedBoxedFloatValues(),
+                o.getAddedBoxedIntValues(),
+                o.getAddedBoxedLongValues(),
+                o.getAddedBoxedShortValues(),
+                o.getAddedBuffers(),
+                o.getAddedHttpMethods(),
+                o.getAddedJsonArrays(),
+                o.getAddedJsonObjects(),
+                o.getAddedObjects(),
+                o.getAddedStringValues(),
+                o.getAggregatedDataObject(),
+                o.getAggregatedDataObjectMap(),
+                o.getAggregatedDataObjectSet(),
+                o.getAggregatedDataObjects(),
+                o.isBooleanValue(),
+                o.getBoxedBooleanSet(),
+                o.isBoxedBooleanValue(),
+                o.getBoxedBooleanValueMap(),
+                o.getBoxedBooleanValues(),
+                o.getBoxedByteSet(),
+                o.getBoxedByteValue(),
+                o.getBoxedByteValueMap(),
+                o.getBoxedByteValues(),
+                o.getBoxedCharSet(),
+                o.getBoxedCharValue(),
+                o.getBoxedCharValueMap(),
+                o.getBoxedCharValues(),
+                o.getBoxedDoubleSet(),
+                o.getBoxedDoubleValue(),
+                o.getBoxedDoubleValueMap(),
+                o.getBoxedDoubleValues(),
+                o.getBoxedFloatSet(),
+                o.getBoxedFloatValue(),
+                o.getBoxedFloatValueMap(),
+                o.getBoxedFloatValues(),
+                o.getBoxedIntSet(),
+                o.getBoxedIntValue(),
+                o.getBoxedIntValueMap(),
+                o.getBoxedIntValues(),
+                o.getBoxedLongSet(),
+                o.getBoxedLongValue(),
+                o.getBoxedLongValueMap(),
+                o.getBoxedLongValues(),
+                o.getBoxedShortSet(),
+                o.getBoxedShortValue(),
+                o.getBoxedShortValueMap(),
+                o.getBoxedShortValues(),
+                o.getBuffer(),
+                o.getBufferMap(),
+                o.getBufferSet(),
+                o.getBuffers(),
+                o.getByteValue(),
+                o.getCharValue(),
+                o.getDoubleValue(),
+                o.getFloatValue(),
+                o.getHttpMethod(),
+                o.getHttpMethodMap(),
+                o.getHttpMethodSet(),
+                o.getHttpMethods(),
+                o.getIntValue(),
+                o.getJsonArray(),
+                o.getJsonArrayMap(),
+                o.getJsonArraySet(),
+                o.getJsonArrays(),
+                o.getJsonObject(),
+                o.getJsonObjectMap(),
+                o.getJsonObjectSet(),
+                o.getJsonObjects(),
+                o.getKeyedBoxedBooleanValues(),
+                o.getKeyedBoxedByteValues(),
+                o.getKeyedBoxedCharValues(),
+                o.getKeyedBoxedDoubleValues(),
+                o.getKeyedBoxedFloatValues(),
+                o.getKeyedBoxedIntValues(),
+                o.getKeyedBoxedLongValues(),
+                o.getKeyedBoxedShortValues(),
+                o.getKeyedBufferValues(),
+                o.getKeyedDataObjectValues(),
+                o.getKeyedEnumValues(),
+                o.getKeyedJsonArrayValues(),
+                o.getKeyedJsonObjectValues(),
+                o.getKeyedObjectValues(),
+                o.getKeyedStringValues(),
+                o.getLongValue(),
+                o.getObjectMap(),
+                o.getObjectSet(),
+                o.getObjects(),
+                o.getShortValue(),
+                o.getStringSet(),
+                o.getStringValue(),
+                o.getStringValueMap(),
+                o.getStringValues());
+    }
 }

--- a/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
@@ -592,6 +592,23 @@ public class DataObjectTest {
   }
 
   @Test
+  public void testDataObjectEqualsAndHashCode() {
+    TestDataObject lhs = new TestDataObject();
+    assertTrue(TestDataObjectConverter.equals(lhs, lhs)); //equals to itself
+    assertEquals(TestDataObjectConverter.hashCode(lhs), TestDataObjectConverter.hashCode(lhs)); //same hashcode
+
+    TestDataObject rhs = new TestDataObject();
+    assertTrue(rhs != lhs); //assert different memory address
+    assertTrue(TestDataObjectConverter.equals(lhs, rhs)); //equals to object with same field values
+    assertEquals(TestDataObjectConverter.hashCode(lhs), TestDataObjectConverter.hashCode(rhs));
+
+    lhs.setFloatValue(100f);
+    assertFalse(TestDataObjectConverter.equals(lhs, rhs));
+    assertNotEquals(TestDataObjectConverter.hashCode(lhs), TestDataObjectConverter.hashCode(rhs));
+
+  }
+
+  @Test
   public void testEmptyDataObjectToJson() {
 
     TestDataObject obj = new TestDataObject();

--- a/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
@@ -605,8 +605,21 @@ public class DataObjectTest {
     lhs.setFloatValue(100f);
     assertFalse(TestDataObjectConverter.equals(lhs, rhs));
     assertNotEquals(TestDataObjectConverter.hashCode(lhs), TestDataObjectConverter.hashCode(rhs));
-
   }
+
+  @Test
+  public void testDataObjectEqualsAndHashWithGenIgnore() {
+    DataObjectWithGenIgnore lhs = new DataObjectWithGenIgnore("Julien", "Viet");
+    DataObjectWithGenIgnore rhs = new DataObjectWithGenIgnore("Julien", "Viet");
+    assertEquals(DataObjectWithGenIgnoreConverter.hashCode(lhs), DataObjectWithGenIgnoreConverter.hashCode(lhs)); //same hashcode
+    assertTrue(DataObjectWithGenIgnoreConverter.equals(lhs, rhs)); //equals
+    assertTrue(DataObjectWithGenIgnoreConverter.equals(lhs, lhs)); //equals to itself
+
+    DataObjectWithGenIgnore other = new DataObjectWithGenIgnore("Farid", "Zakaria");
+    assertNotEquals(DataObjectWithGenIgnoreConverter.hashCode(lhs), DataObjectWithGenIgnoreConverter.hashCode(other)); //same hashcode
+    assertFalse(DataObjectWithGenIgnoreConverter.equals(lhs, other)); //same hashcode
+  }
+
 
   @Test
   public void testEmptyDataObjectToJson() {

--- a/src/test/java/io/vertx/test/codegen/converter/DataObjectWithGenIgnore.java
+++ b/src/test/java/io/vertx/test/codegen/converter/DataObjectWithGenIgnore.java
@@ -1,0 +1,45 @@
+package io.vertx.test.codegen.converter;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonObject;
+
+@DataObject(generateConverter = true)
+public class DataObjectWithGenIgnore {
+
+  private String firstName;
+
+  private String lastName;
+
+  public DataObjectWithGenIgnore() {
+  }
+
+  public DataObjectWithGenIgnore(JsonObject json) {
+  }
+
+  public DataObjectWithGenIgnore(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  @GenIgnore
+  public String getFullName() {
+    return String.format("%s %s", firstName, lastName);
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+}


### PR DESCRIPTION
Add equals & hashCode helper methods for generated DataObject annotated classes.

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>