### PR TITLE
DataObject generation should have option for inheriting equals/hashCode help methods

### DIFF
--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -64,18 +64,18 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
       writer.print("\n");
     }
     if (model.getGenerateEquals()) {
-      generateEquals(model, writer);
+      generateEquals(model, inheritConverter, writer);
       writer.print("\n");
     }
     if (model.getGenerateHashCode()) {
-      generateHashCode(model, writer);
+      generateHashCode(model, inheritConverter, writer);
       writer.print("\n");
     }
     writer.print("}\n");
     return buffer.toString();
   }
 
-  private void generateEquals(DataObjectModel model, PrintWriter writer) {
+  private void generateEquals(DataObjectModel model, boolean inheritConverter, PrintWriter writer) {
     String simpleName = model.getType().getSimpleName();
     writer.println(String.format("    public static boolean equals(%s lhs, %s rhs) {", simpleName, simpleName));
     writer.println("        if (lhs == rhs) {");
@@ -84,6 +84,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.println("");
     writer.print("        return ");
     String equalsString = model.getPropertyMap().values().stream()
+      .filter(prop -> prop.isDeclared() || inheritConverter)
       .filter(prop -> Objects.nonNull(prop.getGetterMethod()))
       .map(prop -> String.format("Objects.equals(lhs.%s(), rhs.%s())", prop.getGetterMethod(), prop.getGetterMethod()))
       .collect(Collectors.joining(" &&\n            "));
@@ -91,10 +92,11 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.println("    }");
   }
 
-  private void generateHashCode(DataObjectModel model, PrintWriter writer) {
+  private void generateHashCode(DataObjectModel model, boolean inheritConverter, PrintWriter writer) {
     String simpleName = model.getType().getSimpleName();
     writer.println(String.format("    public static int hashCode(%s o) {", simpleName));
     String equalsString = model.getPropertyMap().values().stream()
+      .filter(prop -> prop.isDeclared() || inheritConverter)
       .filter(prop -> Objects.nonNull(prop.getGetterMethod()))
       .map(prop -> String.format("                o.%s()", prop.getGetterMethod()))
       .collect(Collectors.joining(",\n"));

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectHelper.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectHelper.java
@@ -1,0 +1,58 @@
+package io.vertx.test.codegen.converter;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.Objects;
+
+/**
+ * Converter for {@link io.vertx.test.codegen.converter.ChildInheritingDataObject}.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.test.codegen.converter.ChildInheritingDataObject} original class using Vert.x codegen.
+ */
+public class ChildInheritingDataObjectHelper {
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ChildInheritingDataObject obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "childProperty":
+          if (member.getValue() instanceof String) {
+            obj.setChildProperty((String)member.getValue());
+          }
+          break;
+        case "parentProperty":
+          if (member.getValue() instanceof String) {
+            obj.setParentProperty((String)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ChildInheritingDataObject obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ChildInheritingDataObject obj, java.util.Map<String, Object> json) {
+    if (obj.getChildProperty() != null) {
+      json.put("childProperty", obj.getChildProperty());
+    }
+    if (obj.getParentProperty() != null) {
+      json.put("parentProperty", obj.getParentProperty());
+    }
+  }
+
+    public static boolean equals(ChildInheritingDataObject lhs, ChildInheritingDataObject rhs) {
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getChildProperty(), rhs.getChildProperty()) &&
+            Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+    }
+
+    public static int hashCode(ChildInheritingDataObject o) {
+        return Objects.hash(
+                o.getChildProperty(),
+                o.getParentProperty());
+    }
+
+}

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectHelper.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectHelper.java
@@ -1,0 +1,48 @@
+package io.vertx.test.codegen.converter;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.Objects;
+
+/**
+ * Converter for {@link io.vertx.test.codegen.converter.ChildNotInheritingDataObject}.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.test.codegen.converter.ChildNotInheritingDataObject} original class using Vert.x codegen.
+ */
+public class ChildNotInheritingDataObjectHelper {
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ChildNotInheritingDataObject obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "childProperty":
+          if (member.getValue() instanceof String) {
+            obj.setChildProperty((String)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ChildNotInheritingDataObject obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ChildNotInheritingDataObject obj, java.util.Map<String, Object> json) {
+    if (obj.getChildProperty() != null) {
+      json.put("childProperty", obj.getChildProperty());
+    }
+  }
+
+    public static boolean equals(ChildNotInheritingDataObject lhs, ChildNotInheritingDataObject rhs) {
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getChildProperty(), rhs.getChildProperty());
+    }
+
+    public static int hashCode(ChildNotInheritingDataObject o) {
+        return Objects.hash(
+                o.getChildProperty());
+    }
+
+}

--- a/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectHelper.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectHelper.java
@@ -1,0 +1,48 @@
+package io.vertx.test.codegen.converter;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.Objects;
+
+/**
+ * Converter for {@link io.vertx.test.codegen.converter.ParentDataObject}.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.test.codegen.converter.ParentDataObject} original class using Vert.x codegen.
+ */
+public class ParentDataObjectHelper {
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ParentDataObject obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "parentProperty":
+          if (member.getValue() instanceof String) {
+            obj.setParentProperty((String)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ParentDataObject obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ParentDataObject obj, java.util.Map<String, Object> json) {
+    if (obj.getParentProperty() != null) {
+      json.put("parentProperty", obj.getParentProperty());
+    }
+  }
+
+    public static boolean equals(ParentDataObject lhs, ParentDataObject rhs) {
+        if (lhs == rhs) {
+          return true;
+        }
+
+        return Objects.equals(lhs.getParentProperty(), rhs.getParentProperty());
+    }
+
+    public static int hashCode(ParentDataObject o) {
+        return Objects.hash(
+                o.getParentProperty());
+    }
+
+}

--- a/src/test/java/io/vertx/test/codegen/converter/ChildInheritingDataObject.java
+++ b/src/test/java/io/vertx/test/codegen/converter/ChildInheritingDataObject.java
@@ -17,7 +17,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@DataObject(inheritConverter = true, generateConverter = true)
+@DataObject(inheritConverter = true, generateConverter = true, generateEquals = true, generateHashCode = true)
 public class ChildInheritingDataObject extends ParentDataObject {
 
   private String childProperty;

--- a/src/test/java/io/vertx/test/codegen/converter/ChildNotInheritingDataObject.java
+++ b/src/test/java/io/vertx/test/codegen/converter/ChildNotInheritingDataObject.java
@@ -17,7 +17,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@DataObject(inheritConverter = false, generateConverter = true)
+@DataObject(inheritConverter = false, generateConverter = true, generateEquals = true, generateHashCode = true)
 public class ChildNotInheritingDataObject extends ParentDataObject {
 
   private String childProperty;

--- a/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
@@ -620,6 +620,35 @@ public class DataObjectTest {
     assertFalse(DataObjectWithGenIgnoreHelper.equals(lhs, other)); //same hashcode
   }
 
+  @Test
+  public void testDataObjectEqualsAndHashCodeDontInherit() {
+    ChildNotInheritingDataObject lhs = new ChildNotInheritingDataObject()
+      .setChildProperty("child").setParentProperty("mom");
+    ChildNotInheritingDataObject rhs = new ChildNotInheritingDataObject()
+      .setChildProperty("child").setParentProperty("dad");
+
+    //This DataObject ignore parent properties so they should be equal
+    //even though the parent property differs
+    assertEquals(ChildNotInheritingDataObjectHelper.hashCode(lhs), ChildNotInheritingDataObjectHelper.hashCode(lhs));
+    assertEquals(ChildNotInheritingDataObjectHelper.hashCode(lhs), ChildNotInheritingDataObjectHelper.hashCode(rhs));
+    assertTrue(ChildNotInheritingDataObjectHelper.equals(rhs, lhs));
+    //The parent is not equals
+    assertNotEquals(ParentDataObjectHelper.hashCode(lhs), ParentDataObjectHelper.hashCode(rhs));
+  }
+
+  @Test
+  public void testDataObjectEqualsAndHashCodeInherit() {
+    ChildInheritingDataObject lhs = new ChildInheritingDataObject()
+      .setChildProperty("child").setParentProperty("mom");
+    ChildInheritingDataObject rhs = new ChildInheritingDataObject()
+      .setChildProperty("child").setParentProperty("dad");
+
+    //This DataObject inherits parent properties so they should be not equal
+    assertEquals(ChildInheritingDataObjectHelper.hashCode(lhs), ChildInheritingDataObjectHelper.hashCode(lhs));
+    assertNotEquals(ChildInheritingDataObjectHelper.hashCode(lhs), ChildInheritingDataObjectHelper.hashCode(rhs));
+    assertFalse(ChildInheritingDataObjectHelper.equals(rhs, lhs));
+  }
+
 
   @Test
   public void testEmptyDataObjectToJson() {

--- a/src/test/java/io/vertx/test/codegen/converter/ParentDataObject.java
+++ b/src/test/java/io/vertx/test/codegen/converter/ParentDataObject.java
@@ -17,7 +17,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@DataObject(generateConverter = true)
+@DataObject(generateConverter = true, generateHashCode = true, generateEquals = true)
 public class ParentDataObject {
 
   private String parentProperty;


### PR DESCRIPTION
DataObject generation should respect the setting whether or not to
inherit properties from the parent class.

fixes https://github.com/vert-x3/vertx-codegen/issues/188

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>