### PR TITLE
support Instant in DataObject converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,9 +368,10 @@ to Json (via the `toJson` method).
 Data object converter can be generated with `@DataObject(generateConverter=true)` by Vert.x Core. Such
  Data object conversion recognize the following types as _member_ of any `@DataObject`:
 
-* the specific `io.vertx.core.Buffer` type
 * the set _`Basic`_
-* the `java.time.Instant` type
+* these specific types
+    * `io.vertx.core.Buffer`
+    * `java.time.Instant`
 * the set _`Json`_
 * any data object class annotated with `@DataObject`
 * type `java.util.List<C>` where `C` contains

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Data object converter can be generated with `@DataObject(generateConverter=true)
 
 * the specific `io.vertx.core.Buffer` type
 * the set _`Basic`_
+* the `java.time.Instant` type
 * the set _`Json`_
 * any data object class annotated with `@DataObject`
 * type `java.util.List<C>` where `C` contains

--- a/src/main/java/io/vertx/codegen/DataObjectModel.java
+++ b/src/main/java/io/vertx/codegen/DataObjectModel.java
@@ -13,6 +13,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import java.time.Instant;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -483,7 +484,6 @@ public class DataObjectModel implements Model {
       case PRIMITIVE:
       case BOXED_PRIMITIVE:
       case STRING:
-      case INSTANT:
       case API:
       case JSON_OBJECT:
       case JSON_ARRAY:
@@ -495,6 +495,12 @@ public class DataObjectModel implements Model {
         jsonifiable = propTypeElt.getAnnotation(DataObject.class) == null ||
           Helper.isJsonifiable(elementUtils, typeUtils, (TypeElement) propTypeElt);
         break;
+      case OTHER:
+        if (propType.getName().equals(Instant.class.getName())) {
+          jsonifiable = true;
+          break;
+        }
+        return;
       default:
         return;
     }

--- a/src/main/java/io/vertx/codegen/DataObjectModel.java
+++ b/src/main/java/io/vertx/codegen/DataObjectModel.java
@@ -483,6 +483,7 @@ public class DataObjectModel implements Model {
       case PRIMITIVE:
       case BOXED_PRIMITIVE:
       case STRING:
+      case INSTANT:
       case API:
       case JSON_OBJECT:
       case JSON_ARRAY:

--- a/src/main/java/io/vertx/codegen/generators/cheatsheet/DataObjectCheatsheetGen.java
+++ b/src/main/java/io/vertx/codegen/generators/cheatsheet/DataObjectCheatsheetGen.java
@@ -10,6 +10,7 @@ import io.vertx.codegen.type.TypeInfo;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 
@@ -111,6 +112,12 @@ public class DataObjectCheatsheetGen extends Generator<DataObjectModel> {
           if (type.getName().equals("io.vertx.core.buffer.Buffer")) {
             return "Buffer";
           }
+          break;
+        case OTHER:
+          if (type.getName().equals(Instant.class.getName())) {
+            return "Instant";
+          }
+          break;
       }
     }
     System.out.println("unhandled type " + type);

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -39,6 +39,8 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.print("\n");
     writer.print("import io.vertx.core.json.JsonObject;\n");
     writer.print("import io.vertx.core.json.JsonArray;\n");
+    writer.print("import java.time.Instant;\n");
+    writer.print("import java.time.format.DateTimeFormatter;\n");
     writer.print("\n");
     writer.print("/**\n");
     writer.print(" * Converter for {@link " + model.getType() + "}.\n");
@@ -66,6 +68,8 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
         if (propKind.basic) {
           if (propKind == ClassKind.STRING) {
             genPropToJson("", "", prop, writer);
+          } else if (propKind == ClassKind.INSTANT) {
+            genPropToJson("DateTimeFormatter.ISO_INSTANT.format(", ")", prop, writer);
           } else {
             switch (prop.getType().getSimpleName()) {
               case "char":
@@ -139,6 +143,8 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
         if (propKind.basic) {
           if (propKind == ClassKind.STRING) {
             genPropFromJson("String", "(String)", "", prop, writer);
+          } else if (propKind == ClassKind.INSTANT) {
+            genPropFromJson("String", "Instant.from(DateTimeFormatter.ISO_INSTANT.parse((String)", "))", prop, writer);
           } else {
             switch (prop.getType().getSimpleName()) {
               case "boolean":

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -7,6 +7,7 @@ import io.vertx.codegen.type.ClassKind;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 
@@ -68,8 +69,6 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
         if (propKind.basic) {
           if (propKind == ClassKind.STRING) {
             genPropToJson("", "", prop, writer);
-          } else if (propKind == ClassKind.INSTANT) {
-            genPropToJson("DateTimeFormatter.ISO_INSTANT.format(", ")", prop, writer);
           } else {
             switch (prop.getType().getSimpleName()) {
               case "char":
@@ -97,6 +96,11 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
               break;
             case DATA_OBJECT:
               genPropToJson("", ".toJson()", prop, writer);
+              break;
+            case OTHER:
+              if (prop.getType().getName().equals(Instant.class.getName())) {
+                genPropToJson("DateTimeFormatter.ISO_INSTANT.format(", ")", prop, writer);
+              }
               break;
           }
         }
@@ -143,8 +147,6 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
         if (propKind.basic) {
           if (propKind == ClassKind.STRING) {
             genPropFromJson("String", "(String)", "", prop, writer);
-          } else if (propKind == ClassKind.INSTANT) {
-            genPropFromJson("String", "Instant.from(DateTimeFormatter.ISO_INSTANT.parse((String)", "))", prop, writer);
           } else {
             switch (prop.getType().getSimpleName()) {
               case "boolean":
@@ -202,6 +204,11 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
               break;
             case OBJECT:
               genPropFromJson("Object", "", "", prop, writer);
+              break;
+            case OTHER:
+              if (prop.getType().getName().equals(Instant.class.getName())) {
+                genPropFromJson("String", "Instant.from(DateTimeFormatter.ISO_INSTANT.parse((String)", "))", prop, writer);
+              }
               break;
             default:
           }

--- a/src/main/java/io/vertx/codegen/type/ClassKind.java
+++ b/src/main/java/io/vertx/codegen/type/ClassKind.java
@@ -18,7 +18,6 @@ public enum ClassKind {
   STRING(true, false, false),
   BOXED_PRIMITIVE(true, false, false),
   PRIMITIVE(true, false, false),
-  INSTANT(true, false, false),
 
   // Enum
   ENUM(false, false, false),
@@ -104,8 +103,6 @@ public enum ClassKind {
       return OBJECT;
     } else if (fqcn.equals(String.class.getName())) {
       return STRING;
-    } else if(fqcn.equals(Instant.class.getName())) {
-      return INSTANT;
     } else if (fqcn.equals(List.class.getName())) {
       return LIST;
     } else if (fqcn.equals(Set.class.getName())) {

--- a/src/main/java/io/vertx/codegen/type/ClassKind.java
+++ b/src/main/java/io/vertx/codegen/type/ClassKind.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.type;
 
 import io.vertx.codegen.ClassModel;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ public enum ClassKind {
   STRING(true, false, false),
   BOXED_PRIMITIVE(true, false, false),
   PRIMITIVE(true, false, false),
+  INSTANT(true, false, false),
 
   // Enum
   ENUM(false, false, false),
@@ -102,6 +104,8 @@ public enum ClassKind {
       return OBJECT;
     } else if (fqcn.equals(String.class.getName())) {
       return STRING;
+    } else if(fqcn.equals(Instant.class.getName())) {
+      return INSTANT;
     } else if (fqcn.equals(List.class.getName())) {
       return LIST;
     } else if (fqcn.equals(Set.class.getName())) {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -1,5 +1,6 @@
 package io.vertx.core.json;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -62,6 +63,8 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>> {
   public JsonObject getJsonObject(String name) { throw new UnsupportedOperationException(); }
   public String getString(String name) { throw new UnsupportedOperationException(); }
   public String getString(String name, String def) { throw new UnsupportedOperationException(); }
+  public Instant getInstant(String name) { throw new UnsupportedOperationException(); }
+  public Instant getInstant(String name, Instant def) { throw new UnsupportedOperationException(); }
   public Integer getInteger(String fieldName) { throw new UnsupportedOperationException(); }
   public Boolean getBoolean(String fieldName, Boolean def) { throw new UnsupportedOperationException(); }
   public Integer getInteger(String fieldName, Integer def) { throw new UnsupportedOperationException(); }

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectTCKImpl.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectTCKImpl.java
@@ -4,6 +4,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.Assert;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     dataObject.setBoxedFloatValue(2.2f);
     dataObject.setBoxedDoubleValue(2.22d);
     dataObject.setStringValue("wibble");
+    dataObject.setInstantValue(Instant.parse("1984-05-27T00:05:00Z"));
     dataObject.setJsonObjectValue(new JsonObject().put("foo", "eek").put("bar", "wibble"));
     dataObject.setJsonArrayValue(new JsonArray().add("eek").add("wibble"));
     dataObject.setEnumValue(TestEnum.TIM);
@@ -55,6 +57,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     assertEquals(2.2f, dataObject.boxedFloatValue, 0.01f);
     assertEquals(2.22f, dataObject.boxedDoubleValue, 0.01f);
     assertEquals("wibble", dataObject.stringValue);
+    assertEquals(Instant.parse("1984-05-27T00:05:00Z"), dataObject.instantValue);
     assertEquals(new JsonObject().put("foo", "eek").put("bar", "wibble"), dataObject.jsonObjectValue);
     assertEquals(new JsonArray().add("eek").add("wibble"), dataObject.jsonArrayValue);
     assertEquals(TestEnum.TIM, dataObject.enumValue);
@@ -74,6 +77,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     dataObject.setFloatValues(Arrays.asList(1.1f, 2.2f, 3.3f));
     dataObject.setDoubleValues(Arrays.asList(1.11d, 2.22d, 3.33d));
     dataObject.setStringValues(Arrays.asList("stringValues1", "stringValues2", "stringValues3"));
+    dataObject.setInstantValues(Arrays.asList(Instant.parse("1984-05-27T00:05:00Z"), Instant.parse("2018-07-05T08:23:21Z")));
     dataObject.setJsonObjectValues(Arrays.asList(new JsonObject().put("foo", "eek"), new JsonObject().put("foo", "wibble")));
     dataObject.setJsonArrayValues(Arrays.asList(new JsonArray().add("foo"), new JsonArray().add("bar")));
     dataObject.setDataObjectValues(Arrays.asList(new TestDataObject().setFoo("1").setBar(1).setWibble(1.1), new TestDataObject().setFoo("2").setBar(2).setWibble(2.2)));
@@ -91,6 +95,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     assertEquals(Arrays.asList(1.1f, 2.2f, 3.3f), dataObject.floatValues);
     assertEquals(Arrays.asList(1.11d, 2.22d, 3.33d), dataObject.doubleValues);
     assertEquals(Arrays.asList("stringValues1", "stringValues2", "stringValues3"), dataObject.stringValues);
+    assertEquals(Arrays.asList(Instant.parse("1984-05-27T00:05:00Z"), Instant.parse("2018-07-05T08:23:21Z")), dataObject.instantValues);
     assertEquals(Arrays.asList(new JsonObject().put("foo", "eek"), new JsonObject().put("foo", "wibble")), dataObject.jsonObjectValues);
     assertEquals(Arrays.asList(new JsonArray().add("foo"), new JsonArray().add("bar")), dataObject.jsonArrayValues);
     assertEquals(2, dataObject.dataObjectValues.size());
@@ -121,6 +126,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     dataObject.setFloatValues(map(1.1f, 2.2f));
     dataObject.setDoubleValues(map(1.11d, 2.22d));
     dataObject.setStringValues(map("stringValues1", "stringValues2"));
+    dataObject.setInstantValues(map(Instant.parse("1984-05-27T00:05:00Z"), Instant.parse("2018-07-05T08:23:21Z")));
     dataObject.setJsonObjectValues(map(new JsonObject().put("foo", "eek"), new JsonObject().put("foo", "wibble")));
     dataObject.setJsonArrayValues(map(new JsonArray().add("foo"), new JsonArray().add("bar")));
     dataObject.setDataObjectValues(map(new TestDataObject().setFoo("1").setBar(1).setWibble(1.1), new TestDataObject().setFoo("2").setBar(2).setWibble(2.2)));
@@ -148,6 +154,7 @@ public class DataObjectTCKImpl implements DataObjectTCK {
     assertMap(dataObject.floatValues, 1.1f, 2.2f, (f1, f2) -> assertEquals(f1, f2, 0.1d));
     assertMap(dataObject.doubleValues, 1.11d, 2.22d, (f1, f2) -> assertEquals(f1, f2, 0.1d));
     assertMap(dataObject.stringValues, "stringValues1", "stringValues2");
+    assertMap(dataObject.instantValues, Instant.parse("1984-05-27T00:05:00Z"), Instant.parse("2018-07-05T08:23:21Z"));
     assertMap(dataObject.jsonObjectValues, new JsonObject().put("foo", "eek"), new JsonObject().put("foo", "wibble"));
     assertMap(dataObject.jsonArrayValues, new JsonArray().add("foo"), new JsonArray().add("bar"));
     assertEquals(2, dataObject.dataObjectValues.size());

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithListAdders.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithListAdders.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -55,6 +57,11 @@ public class DataObjectWithListAdders {
 
   public DataObjectWithListAdders addStringValue(String stringValue) {
     value.stringValues.add(stringValue);
+    return this;
+  }
+
+  public DataObjectWithListAdders addInstantValue(Instant instantValue) {
+    value.instantValues.add(instantValue);
     return this;
   }
 

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
@@ -64,7 +64,7 @@ public class DataObjectWithLists {
     floatValues = fromArray(json, "floatValues", o -> Float.parseFloat(o.toString()));
     doubleValues = fromArray(json, "doubleValues");
     stringValues = fromArray(json, "stringValues");
-    instantValues = fromArray(json, "instantValues");
+    instantValues = fromArray(json, "instantValues", o -> Instant.parse(o.toString()));
     jsonObjectValues = fromArray(json, "jsonObjectValues", o -> (JsonObject) o);
     jsonArrayValues = fromArray(json, "jsonArrayValues", o -> (JsonArray) o);
     dataObjectValues = fromArray(json, "dataObjectValues", o -> new TestDataObject((JsonObject) o));
@@ -161,7 +161,7 @@ public class DataObjectWithLists {
       json.put("stringValues", toArray(stringValues));
     }
     if (instantValues != null) {
-      json.put("instantValues", toArray(instantValues));
+      json.put("instantValues", toArray(instantValues.stream().map(Instant::toString).collect(Collectors.toList())));
     }
     if (jsonObjectValues != null) {
       json.put("jsonObjectValues", toArray(jsonObjectValues));

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithLists.java
@@ -4,9 +4,9 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -42,6 +42,7 @@ public class DataObjectWithLists {
   List<Double> doubleValues = new ArrayList<>();
   List<Boolean> booleanValues = new ArrayList<>();
   List<String> stringValues = new ArrayList<>();
+  List<Instant> instantValues = new ArrayList<>();
   List<JsonObject> jsonObjectValues = new ArrayList<>();
   List<JsonArray> jsonArrayValues = new ArrayList<>();
   List<TestDataObject> dataObjectValues = new ArrayList<>();
@@ -63,6 +64,7 @@ public class DataObjectWithLists {
     floatValues = fromArray(json, "floatValues", o -> Float.parseFloat(o.toString()));
     doubleValues = fromArray(json, "doubleValues");
     stringValues = fromArray(json, "stringValues");
+    instantValues = fromArray(json, "instantValues");
     jsonObjectValues = fromArray(json, "jsonObjectValues", o -> (JsonObject) o);
     jsonArrayValues = fromArray(json, "jsonArrayValues", o -> (JsonArray) o);
     dataObjectValues = fromArray(json, "dataObjectValues", o -> new TestDataObject((JsonObject) o));
@@ -102,6 +104,11 @@ public class DataObjectWithLists {
 
   public DataObjectWithLists setStringValues(List<String> stringValue) {
     this.stringValues = stringValue;
+    return this;
+  }
+
+  public DataObjectWithLists setInstantValues(List<Instant> instantValues) {
+    this.instantValues = instantValues;
     return this;
   }
 
@@ -152,6 +159,9 @@ public class DataObjectWithLists {
     }
     if (stringValues != null) {
       json.put("stringValues", toArray(stringValues));
+    }
+    if (instantValues != null) {
+      json.put("instantValues", toArray(instantValues));
     }
     if (jsonObjectValues != null) {
       json.put("jsonObjectValues", toArray(jsonObjectValues));

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMapAdders.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMapAdders.java
@@ -4,9 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
+import java.time.Instant;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -59,6 +57,11 @@ public class DataObjectWithMapAdders {
 
   public DataObjectWithMapAdders addStringValue(String key, String stringValue) {
     value.stringValues.put(key, stringValue);
+    return this;
+  }
+
+  public DataObjectWithMapAdders addInstantValue(String key, Instant instantValue) {
+    value.instantValues.put(key, instantValue);
     return this;
   }
 

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
@@ -71,6 +71,7 @@ public class DataObjectWithMaps {
     floatValues = fromObject(json, "floatValues", o -> Float.parseFloat(o.toString()));
     doubleValues = fromObject(json, "doubleValues");
     stringValues = fromObject(json, "stringValues");
+    instantValues = fromObject(json, "instantValues", (o -> Instant.parse(o.toString())));
     jsonObjectValues = fromObject(json, "jsonObjectValues", o -> (JsonObject) o);
     jsonArrayValues = fromObject(json, "jsonArrayValues", o -> (JsonArray) o);
     dataObjectValues = fromObject(json, "dataObjectValues", o -> new TestDataObject((JsonObject) o));
@@ -165,6 +166,9 @@ public class DataObjectWithMaps {
     }
     if (stringValues != null) {
       json.put("stringValues", toObject(stringValues));
+    }
+    if (instantValues != null) {
+      json.put("instantValues", toObject(instantValues, Instant::toString));
     }
     if (jsonObjectValues != null) {
       json.put("jsonObjectValues", toObject(jsonObjectValues));

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithMaps.java
@@ -1,5 +1,6 @@
 package io.vertx.codegen.testmodel;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -48,6 +49,7 @@ public class DataObjectWithMaps {
   Map<String, Double> doubleValues = new HashMap<>();
   Map<String, Boolean> booleanValues = new HashMap<>();
   Map<String, String> stringValues = new HashMap<>();
+  Map<String, Instant> instantValues = new HashMap<>();
   Map<String, JsonObject> jsonObjectValues = new HashMap<>();
   Map<String, JsonArray> jsonArrayValues = new HashMap<>();
   Map<String, TestDataObject> dataObjectValues = new HashMap<>();
@@ -108,6 +110,11 @@ public class DataObjectWithMaps {
 
   public DataObjectWithMaps setStringValues(Map<String, String> stringValue) {
     this.stringValues = stringValue;
+    return this;
+  }
+
+  public DataObjectWithMaps setInstantValues(Map<String, Instant> instantValues) {
+    this.instantValues = instantValues;
     return this;
   }
 

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithValues.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithValues.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -23,6 +25,7 @@ public class DataObjectWithValues {
   Double boxedDoubleValue;
   Boolean boxedBooleanValue;
   String stringValue;
+  Instant instantValue;
   JsonObject jsonObjectValue;
   JsonArray jsonArrayValue;
   TestDataObject dataObjectValue;
@@ -50,6 +53,7 @@ public class DataObjectWithValues {
     boxedFloatValue = json.getFloat("boxedFloatValue", null);
     boxedDoubleValue = json.getDouble("boxedDoubleValue", null);
     stringValue = json.getString("stringValue");
+    instantValue = json.getInstant("instantValue");
     jsonObjectValue = json.getJsonObject("jsonObjectValue");
     jsonArrayValue = json.getJsonArray("jsonArrayValue");
     dataObjectValue = json.getJsonObject("dataObjectValue") != null ? new TestDataObject(json.getJsonObject("dataObjectValue")) : null;
@@ -116,6 +120,11 @@ public class DataObjectWithValues {
     return this;
   }
 
+  public DataObjectWithValues setInstantValue(Instant instantValue) {
+    this.instantValue = instantValue;
+    return this;
+  }
+
   public DataObjectWithValues setJsonObjectValue(JsonObject jsonObjectValue) {
     this.jsonObjectValue = jsonObjectValue;
     return this;
@@ -163,6 +172,9 @@ public class DataObjectWithValues {
     }
     if (stringValue != null) {
       json.put("stringValue", stringValue);
+    }
+    if (instantValue != null) {
+      json.put("instantValue", stringValue);
     }
     if (jsonObjectValue != null) {
       json.put("jsonObjectValue", jsonObjectValue);

--- a/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithValues.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/DataObjectWithValues.java
@@ -174,7 +174,7 @@ public class DataObjectWithValues {
       json.put("stringValue", stringValue);
     }
     if (instantValue != null) {
-      json.put("instantValue", stringValue);
+      json.put("instantValue", instantValue);
     }
     if (jsonObjectValue != null) {
       json.put("jsonObjectValue", jsonObjectValue);

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -2,6 +2,8 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ChildInheritingDataObject}.

--- a/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -2,6 +2,8 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ChildNotInheritingDataObject}.

--- a/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -2,6 +2,8 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.ParentDataObject}.

--- a/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -2,6 +2,8 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.SetterAdderDataObject}.

--- a/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/test/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -2,6 +2,8 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter for {@link io.vertx.test.codegen.converter.TestDataObject}.

--- a/src/test/java/io/vertx/test/codegen/CodeGeneratorTest.java
+++ b/src/test/java/io/vertx/test/codegen/CodeGeneratorTest.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.Callable;
 
@@ -96,7 +97,7 @@ public class CodeGeneratorTest {
     assertEquals("false", props.remove("concrete"));
     assertEquals("false", props.remove("isClass"));
     assertEquals("[" + JsonArray.class.getName() + ", " + JsonObject.class.getName() + ", " + Boolean.class.getName() + ", "
-        + Integer.class.getName() + ", " + Long.class.getName() + ", " + String.class.getName()
+        + Integer.class.getName() + ", " + Long.class.getName() + ", " + String.class.getName() + ", " + Instant.class.getName()
         + "]", props.remove("importedTypes"));
     assertEquals("[]", props.remove("superTypes"));
     assertEquals("[]", props.remove("abstractSuperTypes"));
@@ -113,6 +114,7 @@ public class CodeGeneratorTest {
     assertEquals("int", props.remove("property.primitiveInteger"));
     assertEquals("long", props.remove("property.primitiveLong"));
     assertEquals("java.lang.String", props.remove("property.string"));
+    assertEquals("java.time.Instant", props.remove("property.instant"));
     assertEquals("io.vertx.test.codegen.testdataobject.ToJsonDataObject", props.remove("property.toJsonDataObject"));
     assertEquals(new Properties(), props);
   }

--- a/src/test/java/io/vertx/test/codegen/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/DataObjectTest.java
@@ -19,6 +19,7 @@ import io.vertx.test.codegen.testdataobject.*;
 import io.vertx.test.codegen.testdataobject.imported.Imported;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -92,7 +93,7 @@ public class DataObjectTest {
   public void testPropertySetters() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertySetters.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(14, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", "setString", null, null, TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", "setBoxedInteger", null, null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveInteger"), "primitiveInteger", "setPrimitiveInteger", null, null, TypeReflectionFactory.create(int.class), true, PropertyKind.VALUE, true);
@@ -100,6 +101,7 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("primitiveBoolean"), "primitiveBoolean", "setPrimitiveBoolean", null, null, TypeReflectionFactory.create(boolean.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedLong"), "boxedLong", "setBoxedLong", null, null, TypeReflectionFactory.create(Long.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveLong"), "primitiveLong", "setPrimitiveLong", null, null, TypeReflectionFactory.create(long.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("instant"), "instant", "setInstant", null, null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("apiObject"), "apiObject", "setApiObject", null, null, TypeReflectionFactory.create(ApiObject.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("dataObject"), "dataObject", "setDataObject", null, null, TypeReflectionFactory.create(EmptyDataObject.class), true, PropertyKind.VALUE, false);
     assertProperty(model.getPropertyMap().get("toJsonDataObject"), "toJsonDataObject", "setToJsonDataObject", null, null, TypeReflectionFactory.create(ToJsonDataObject.class), true, PropertyKind.VALUE, true);
@@ -131,9 +133,10 @@ public class DataObjectTest {
   private void testPropertyCollectionSetters(Class<?> dataObjectClass, PropertyKind expectedKind) throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(dataObjectClass);
     assertNotNull(model);
-    assertEquals(11, model.getPropertyMap().size());
+    assertEquals(12, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("extraClassPath"), "extraClassPath", "setExtraClassPath", null, null, TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("strings"), "strings", "setStrings", null, null, TypeReflectionFactory.create(String.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", "setInstants", null, null, TypeReflectionFactory.create(Instant.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", "setBoxedIntegers", null, null, TypeReflectionFactory.create(Integer.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", "setBoxedBooleans", null, null, TypeReflectionFactory.create(Boolean.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedLongs"), "boxedLongs", "setBoxedLongs", null, null, TypeReflectionFactory.create(Long.class), true, expectedKind, true);
@@ -158,9 +161,10 @@ public class DataObjectTest {
   private void testPropertyCollectionGettersSetters(Class<?> dataObjectClass, PropertyKind expectedKind) throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(dataObjectClass);
     assertNotNull(model);
-    assertEquals(11, model.getPropertyMap().size());
+    assertEquals(12, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("extraClassPath"), "extraClassPath", "setExtraClassPath", null, "getExtraClassPath", TypeReflectionFactory.create(String.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("strings"), "strings", "setStrings", null, "getStrings", TypeReflectionFactory.create(String.class), true, expectedKind, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", "setInstants", null, "getInstants", TypeReflectionFactory.create(Instant.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", "setBoxedIntegers", null, "getBoxedIntegers", TypeReflectionFactory.create(Integer.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", "setBoxedBooleans", null, "getBoxedBooleans", TypeReflectionFactory.create(Boolean.class), true, expectedKind, true);
     assertProperty(model.getPropertyMap().get("boxedLongs"), "boxedLongs", "setBoxedLongs", null, "getBoxedLongs", TypeReflectionFactory.create(Long.class), true, expectedKind, true);
@@ -180,8 +184,9 @@ public class DataObjectTest {
   public void testPropertyMapGettersSetters() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyMapGettersSetters.class);
     assertNotNull(model);
-    assertEquals(11, model.getPropertyMap().size());
+    assertEquals(12, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("stringMap"), "stringMap", "setStringMap", null, "getStringMap", TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("instantMap"), "instantMap", "setInstantMap", null, "getInstantMap", TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegerMap"), "boxedIntegerMap", "setBoxedIntegerMap", null, "getBoxedIntegerMap", TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedBooleanMap"), "boxedBooleanMap", "setBoxedBooleanMap", null, "getBoxedBooleanMap", TypeReflectionFactory.create(Boolean.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedLongMap"), "boxedLongMap", "setBoxedLongMap", null, "getBoxedLongMap", TypeReflectionFactory.create(Long.class), true, PropertyKind.MAP, true);
@@ -198,8 +203,9 @@ public class DataObjectTest {
   public void testPropertyMapAdders() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyMapAdders.class);
     assertNotNull(model);
-    assertEquals(14, model.getPropertyMap().size());
+    assertEquals(15, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", null, TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("primitiveIntegers"), "primitiveIntegers", null, "addPrimitiveInteger", null, TypeReflectionFactory.create(int.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", null, "addBoxedBoolean", null, TypeReflectionFactory.create(Boolean.class), true, PropertyKind.MAP, true);
@@ -219,8 +225,9 @@ public class DataObjectTest {
   public void testPropertyMapSetters() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyMapSetters.class);
     assertNotNull(model);
-    assertEquals(11, model.getPropertyMap().size());
+    assertEquals(12, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("stringMap"), "stringMap", "setStringMap", null, null, TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("instantMap"), "instantMap", "setInstantMap", null, null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegerMap"), "boxedIntegerMap", "setBoxedIntegerMap", null, null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedBooleanMap"), "boxedBooleanMap", "setBoxedBooleanMap", null, null, TypeReflectionFactory.create(Boolean.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedLongMap"), "boxedLongMap", "setBoxedLongMap", null, null, TypeReflectionFactory.create(Long.class), true, PropertyKind.MAP, true);
@@ -237,8 +244,9 @@ public class DataObjectTest {
   public void testPropertyMapSetterAdders() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyMapGettersAdders.class);
     assertNotNull(model);
-    assertEquals(11, model.getPropertyMap().size());
+    assertEquals(12, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", "getStrings", TypeReflectionFactory.create(String.class), true, PropertyKind.MAP, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", "getInstants", TypeReflectionFactory.create(Instant.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", "getBoxedIntegers", TypeReflectionFactory.create(Integer.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", null, "addBoxedBoolean", "getBoxedBooleans", TypeReflectionFactory.create(Boolean.class), true, PropertyKind.MAP, true);
     assertProperty(model.getPropertyMap().get("boxedLongs"), "boxedLongs", null, "addBoxedLong", "getBoxedLongs", TypeReflectionFactory.create(Long.class), true, PropertyKind.MAP, true);
@@ -255,7 +263,7 @@ public class DataObjectTest {
   public void testPropertyGetters() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyGetters.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(14, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", null, null, "getString", TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", null, null, "getBoxedInteger", TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveInteger"), "primitiveInteger", null, null, "getPrimitiveInteger", TypeReflectionFactory.create(int.class), true, PropertyKind.VALUE, true);
@@ -263,6 +271,7 @@ public class DataObjectTest {
     assertProperty(model.getPropertyMap().get("primitiveBoolean"), "primitiveBoolean", null, null, "isPrimitiveBoolean", TypeReflectionFactory.create(boolean.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedLong"), "boxedLong", null, null, "getBoxedLong", TypeReflectionFactory.create(Long.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveLong"), "primitiveLong", null, null, "getPrimitiveLong", TypeReflectionFactory.create(long.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("instant"), "instant", null, null, "getInstant", TypeReflectionFactory.create(Instant.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("apiObject"), "apiObject", null, null, "getApiObject", TypeReflectionFactory.create(ApiObject.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("dataObject"), "dataObject", null, null, "getDataObject", TypeReflectionFactory.create(EmptyDataObject.class), true, PropertyKind.VALUE, false);
     assertProperty(model.getPropertyMap().get("toJsonDataObject"), "toJsonDataObject", null, null, "getToJsonDataObject", TypeReflectionFactory.create(ToJsonDataObject.class), true, PropertyKind.VALUE, true);
@@ -275,8 +284,9 @@ public class DataObjectTest {
   public void testPropertyGettersSetters() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyGettersSetters.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(14, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("string"), "string", "setString", null, "getString", TypeReflectionFactory.create(String.class), true, PropertyKind.VALUE, true);
+    assertProperty(model.getPropertyMap().get("instant"), "instant", "setInstant", null, "getInstant", TypeReflectionFactory.create(Instant.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedInteger"), "boxedInteger", "setBoxedInteger", null, "getBoxedInteger", TypeReflectionFactory.create(Integer.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("primitiveInteger"), "primitiveInteger", "setPrimitiveInteger", null, "getPrimitiveInteger", TypeReflectionFactory.create(int.class), true, PropertyKind.VALUE, true);
     assertProperty(model.getPropertyMap().get("boxedBoolean"), "boxedBoolean", "setBoxedBoolean", null, "isBoxedBoolean", TypeReflectionFactory.create(Boolean.class), true, PropertyKind.VALUE, true);
@@ -303,8 +313,9 @@ public class DataObjectTest {
   public void testPropertyListAdders() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyListAdders.class);
     assertNotNull(model);
-    assertEquals(13, model.getPropertyMap().size());
+    assertEquals(14, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", null, TypeReflectionFactory.create(String.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", null, TypeReflectionFactory.create(Instant.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", null, TypeReflectionFactory.create(Integer.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("primitiveIntegers"), "primitiveIntegers", null, "addPrimitiveInteger", null, TypeReflectionFactory.create(int.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", null, "addBoxedBoolean", null, TypeReflectionFactory.create(Boolean.class), true, PropertyKind.LIST, true);
@@ -323,8 +334,9 @@ public class DataObjectTest {
   public void testPropertyListGettersAdders() throws Exception {
     DataObjectModel model = new GeneratorHelper().generateDataObject(PropertyListGettersAdders.class);
     assertNotNull(model);
-    assertEquals(10, model.getPropertyMap().size());
+    assertEquals(11, model.getPropertyMap().size());
     assertProperty(model.getPropertyMap().get("strings"), "strings", null, "addString", "getStrings", TypeReflectionFactory.create(String.class), true, PropertyKind.LIST, true);
+    assertProperty(model.getPropertyMap().get("instants"), "instants", null, "addInstant", "getInstants", TypeReflectionFactory.create(Instant.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedIntegers"), "boxedIntegers", null, "addBoxedInteger", "getBoxedIntegers", TypeReflectionFactory.create(Integer.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedBooleans"), "boxedBooleans", null, "addBoxedBoolean", "getBoxedBooleans", TypeReflectionFactory.create(Boolean.class), true, PropertyKind.LIST, true);
     assertProperty(model.getPropertyMap().get("boxedLongs"), "boxedLongs", null, "addBoxedLong", "getBoxedLongs", TypeReflectionFactory.create(Long.class), true, PropertyKind.LIST, true);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGetters.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -29,6 +31,7 @@ public class PropertyGetters {
   public boolean isPrimitiveBoolean() { throw new UnsupportedOperationException(); }
   public Long getBoxedLong() { throw new UnsupportedOperationException(); }
   public long getPrimitiveLong() { throw new UnsupportedOperationException(); }
+  public Instant getInstant() { throw new UnsupportedOperationException(); }
 
   public ApiObject getApiObject() { throw new UnsupportedOperationException(); }
   public EmptyDataObject getDataObject() { throw new UnsupportedOperationException(); }

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyGettersSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -22,6 +23,8 @@ public interface PropertyGettersSetters {
 
   void setString(String s);
   String getString();
+  void setInstant(Instant i);
+  Instant getInstant();
   void setBoxedInteger(Integer i);
   Integer getBoxedInteger();
   void setPrimitiveInteger(int i);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListAdders.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -19,6 +21,7 @@ public interface PropertyListAdders {
   }
 
   PropertyListAdders addString(String s);
+  PropertyListAdders addInstant(Instant i);
   PropertyListAdders addBoxedInteger(Integer i);
   PropertyListAdders addPrimitiveInteger(int i);
   PropertyListAdders addBoxedBoolean(Boolean b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersAdders.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -22,6 +23,8 @@ public interface PropertyListGettersAdders {
 
   List<String> getStrings();
   PropertyListGettersAdders addString(String s);
+  List<Instant> getInstants();
+  PropertyListGettersAdders addInstant(Instant i);
   List<Integer> getBoxedIntegers();
   PropertyListGettersAdders addBoxedInteger(Integer i);
   List<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListGettersSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -27,6 +28,8 @@ public interface PropertyListGettersSetters {
   // Regular case
   List<String> getStrings();
   PropertyListGettersSetters setStrings(List<String> s);
+  List<Instant> getInstants();
+  PropertyListGettersSetters setInstants(List<Instant> s);
   List<Integer> getBoxedIntegers();
   PropertyListGettersSetters setBoxedIntegers(List<Integer> i);
   List<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyListSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -25,6 +26,7 @@ public interface PropertyListSetters {
 
   // Regular case
   PropertyListSetters setStrings(List<String> s);
+  PropertyListSetters setInstants(List<Instant> s);
   PropertyListSetters setBoxedIntegers(List<Integer> i);
   PropertyListSetters setBoxedBooleans(List<Boolean> b);
   PropertyListSetters setBoxedLongs(List<Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapAdders.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -22,6 +23,7 @@ public interface PropertyMapAdders {
 
   // Regular case
   PropertyMapAdders addString(String key, String s);
+  PropertyMapAdders addInstant(String key, Instant i);
   PropertyMapAdders addBoxedInteger(String key, Integer i);
   PropertyMapAdders addPrimitiveInteger(String key, int i);
   PropertyMapAdders addBoxedBoolean(String key, Boolean b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersAdders.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersAdders.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -23,6 +24,8 @@ public interface PropertyMapGettersAdders {
   // Regular case
   Map<String, String> getStrings();
   PropertyMapGettersAdders addString(String key, String s);
+  Map<String, Instant> getInstants();
+  PropertyMapGettersAdders addInstant(String key, Instant i);
   Map<String, Integer> getBoxedIntegers();
   PropertyMapGettersAdders addBoxedInteger(String key, Integer i);
   Map<String, Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapGettersSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +25,8 @@ public interface PropertyMapGettersSetters {
   // Regular case
   Map<String, String> getStringMap();
   PropertyMapGettersSetters setStringMap(Map<String, String> s);
+  Map<String, Instant> getInstantMap();
+  PropertyMapGettersSetters setInstantMap(Map<String, Instant> i);
   Map<String, Integer> getBoxedIntegerMap();
   PropertyMapGettersSetters setBoxedIntegerMap(Map<String, Integer> i);
   Map<String, Boolean> getBoxedBooleanMap();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertyMapSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ public interface PropertyMapSetters {
 
   // Regular case
   PropertyMapSetters setStringMap(Map<String, String> s);
+  PropertyMapSetters setInstantMap(Map<String, Instant> i);
   PropertyMapSetters setBoxedIntegerMap(Map<String, Integer> i);
   PropertyMapSetters setBoxedBooleanMap(Map<String, Boolean> b);
   PropertyMapSetters setBoxedLongMap(Map<String, Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetGettersSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetGettersSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.Set;
 
 /**
@@ -27,6 +28,8 @@ public interface PropertySetGettersSetters {
   // Regular case
   Set<String> getStrings();
   PropertySetGettersSetters setStrings(Set<String> s);
+  Set<Instant> getInstants();
+  PropertySetGettersSetters setInstants(Set<Instant> i);
   Set<Integer> getBoxedIntegers();
   PropertySetGettersSetters setBoxedIntegers(Set<Integer> i);
   Set<Boolean> getBoxedBooleans();

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetSetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetSetters.java
@@ -4,6 +4,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
 import java.util.Set;
 
 /**
@@ -25,6 +26,7 @@ public interface PropertySetSetters {
 
   // Regular case
   PropertySetSetters setStrings(Set<String> s);
+  PropertySetSetters setInstants(Set<Instant> i);
   PropertySetSetters setBoxedIntegers(Set<Integer> i);
   PropertySetSetters setBoxedBooleans(Set<Boolean> b);
   PropertySetSetters setBoxedLongs(Set<Long> b);

--- a/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetters.java
+++ b/src/test/java/io/vertx/test/codegen/testdataobject/PropertySetters.java
@@ -4,6 +4,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.Instant;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -29,6 +31,7 @@ public class PropertySetters {
   public PropertySetters setPrimitiveBoolean(boolean b) { throw new UnsupportedOperationException(); }
   public PropertySetters setBoxedLong(Long b) { throw new UnsupportedOperationException(); }
   public PropertySetters setPrimitiveLong(long b) { throw new UnsupportedOperationException(); }
+  public PropertySetters setInstant(Instant i) { throw new UnsupportedOperationException(); }
 
   public PropertySetters setApiObject(ApiObject s) { throw new UnsupportedOperationException(); }
   public PropertySetters setDataObject(EmptyDataObject nested) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
This adds `DataObject` converter support for `java.time.Instant` properties.