### PR TITLE
fix cheatsheet generators

### DIFF
--- a/src/main/java/io/vertx/codegen/generators/cheatsheet/DataObjectCheatsheetGen.java
+++ b/src/main/java/io/vertx/codegen/generators/cheatsheet/DataObjectCheatsheetGen.java
@@ -22,6 +22,11 @@ public class DataObjectCheatsheetGen extends Generator<DataObjectModel> {
   }
 
   @Override
+  public String filename(DataObjectModel model) {
+    return "asciidocs/dataobjects.adoc";
+  }
+
+  @Override
   public String render(DataObjectModel model, int index, int size, Map<String, Object> session) {
     StringWriter buffer = new StringWriter();
     PrintWriter html = new PrintWriter(buffer);
@@ -31,7 +36,7 @@ public class DataObjectCheatsheetGen extends Generator<DataObjectModel> {
     }
     render(model, html);
     html.append("\n");
-    return html.toString();
+    return buffer.toString();
   }
 
   private void render(DataObjectModel model, PrintWriter html) {

--- a/src/main/java/io/vertx/codegen/generators/cheatsheet/EnumCheatsheetGen.java
+++ b/src/main/java/io/vertx/codegen/generators/cheatsheet/EnumCheatsheetGen.java
@@ -23,6 +23,11 @@ public class EnumCheatsheetGen extends Generator<EnumModel> {
   }
 
   @Override
+  public String filename(EnumModel model) {
+    return "asciidocs/enums.adoc";
+  }
+
+  @Override
   public String render(EnumModel model, int index, int size, Map<String, Object> session) {
     StringWriter buffer = new StringWriter();
     PrintWriter html = new PrintWriter(buffer);
@@ -32,7 +37,7 @@ public class EnumCheatsheetGen extends Generator<EnumModel> {
     }
     render(model, html);
     html.append("\n");
-    return html.toString();
+    return buffer.toString();
   }
 
   private void render(EnumModel model, PrintWriter html) {


### PR DESCRIPTION
This fixes the cheatsheet generators (dataobject & enum). Obviously the hard-coded paths to `asciidoc` need to be replaced but I'm not sure where you want to take the path from. Maybe the `docgen.output` option?