### PR TITLE
Isinterface for dos

### DIFF
--- a/src/main/java/io/vertx/codegen/type/DataObjectTypeInfo.java
+++ b/src/main/java/io/vertx/codegen/type/DataObjectTypeInfo.java
@@ -11,14 +11,20 @@ import java.util.List;
 public class DataObjectTypeInfo extends ClassTypeInfo {
 
   final boolean _abstract;
+  final boolean _interface;
 
-  public DataObjectTypeInfo(ClassKind kind, String name, ModuleInfo module, boolean _abstract, boolean nullable, List<TypeParamInfo.Class> params) {
+  public DataObjectTypeInfo(ClassKind kind, String name, ModuleInfo module, boolean _abstract, boolean nullable, boolean _interface, List<TypeParamInfo.Class> params) {
     super(kind, name, module, nullable, params);
 
     this._abstract = _abstract;
+    this._interface = _interface;
   }
 
   public boolean isAbstract() {
     return _abstract;
+  }
+
+  public boolean isInterface() {
+    return _interface;
   }
 }

--- a/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -130,7 +130,8 @@ public class TypeMirrorFactory {
             raw = new ApiTypeInfo(fqcn, genAnn.concrete(), typeParams, handlerArg, module, nullable, proxyGen);
           } else if (kind == ClassKind.DATA_OBJECT) {
             boolean _abstract = elt.getModifiers().contains(Modifier.ABSTRACT);
-            raw = new DataObjectTypeInfo(kind, fqcn, module, _abstract, nullable, typeParams);
+            boolean _interface = elt.getKind().isInterface();
+            raw = new DataObjectTypeInfo(kind, fqcn, module, _abstract, nullable, _interface, typeParams);
           } else {
             raw = new ClassTypeInfo(kind, fqcn, module, nullable, typeParams);
           }

--- a/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
@@ -76,7 +76,8 @@ public class TypeReflectionFactory {
             return new ApiTypeInfo(fqcn, true, typeParams, handlerArg != null ? create(handlerArg) : null, module, false, false);
           } else if (kind == ClassKind.DATA_OBJECT) {
             boolean _abstract = Modifier.isAbstract(classType.getModifiers());
-            return new DataObjectTypeInfo(kind, fqcn, module, _abstract, false, typeParams);
+            boolean _interface = ((Class<?>) type).isInterface();
+            return new DataObjectTypeInfo(kind, fqcn, module, _abstract, false, _interface, typeParams);
           } else {
             return new ClassTypeInfo(kind, fqcn, module, false, typeParams);
           }


### PR DESCRIPTION
## Why
While generating the wrappers for the pg-client I hit the issue that I need to differentiate between three variations of DataObjects:

- concrete ones
- abstract classes
- interfaces

So far only the first two were correctly covered since DataObjectTypeInfo only provided isAbstract.

## What
I simply added the missing information as a isInterface check on DataObjectTypeInfo.