### PR TITLE
Add automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
+    <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 
   <dependencyManagement>
@@ -261,6 +262,9 @@
             <configuration>
               <attach>true</attach>
               <appendAssemblyId>false</appendAssemblyId>
+              <archive>
+                <manifestFile>${jar.manifest}</manifestFile>
+              </archive>
               <descriptors>
                 <descriptor>src/main/assembly/jar.xml</descriptor>
               </descriptors>

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Automatic-Module-Name: io.vertx.codegen
+


### PR DESCRIPTION
Signed-off-by: afloarea <adrianfloarea07@yahoo.com>

Motivation:

Add automatic module name as per vert-x3/issues#524

Note: The codegen build config is a bit more complex and it uses the assembly plugin. As such, the parent pom could not be used directly. Only the vertx-codegen artifact has an automatic module name.
The vertx codegen processor and tck jars do not have automatic module names.