### PR TITLE
Better error messages

### DIFF
--- a/src/main/java/io/vertx/codegen/TypeValidator.java
+++ b/src/main/java/io/vertx/codegen/TypeValidator.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.type.ParameterizedTypeInfo;
 import io.vertx.codegen.type.TypeInfo;
 import io.vertx.codegen.type.TypeVariableInfo;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
@@ -19,16 +20,16 @@ import java.util.Set;
 class TypeValidator {
 
   static void validateParamType(ExecutableElement elem, TypeInfo typeInfo, boolean allowAnyJavaType) {
-    if (isValidNonCallableType(typeInfo, true, false, true, allowAnyJavaType)) {
+    if (isValidNonCallableType(elem, typeInfo, true, false, true, allowAnyJavaType)) {
       return;
     }
     if (isValidClassTypeParam(elem, typeInfo)) {
       return;
     }
-    if (isValidHandlerType(typeInfo, allowAnyJavaType)) {
+    if (isValidHandlerType(elem, typeInfo, allowAnyJavaType)) {
       return;
     }
-    if (isValidFunctionType(typeInfo, allowAnyJavaType)) {
+    if (isValidFunctionType(elem, typeInfo, allowAnyJavaType)) {
       return;
     }
     throw new GenException(elem, "type " + typeInfo + " is not legal for use for a parameter in code generation");
@@ -38,24 +39,24 @@ class TypeValidator {
     if (type.isVoid()) {
       return;
     }
-    if (isValidNonCallableType(type, false, true, true, allowAnyJavaType)) {
+    if (isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType)) {
       return;
     }
-    if (isValidHandlerType(type, allowAnyJavaType)) {
+    if (isValidHandlerType(elem, type, allowAnyJavaType)) {
       return;
     }
     throw new GenException(elem, "type " + type + " is not legal for use for a return type in code generation");
   }
 
   static void validateConstantType(VariableElement elem, TypeInfo type, TypeMirror typeMirror, boolean allowAnyJavaType) {
-    if (isValidNonCallableType(type, false, true, true, allowAnyJavaType)) {
+    if (isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType)) {
       return;
     }
     throw new GenException(elem, "type " + type + " is not legal for use for a constant type in code generation");
   }
 
-  private static boolean isValidNonCallableType(TypeInfo type, boolean isParam, boolean isReturn, boolean allowParameterized, boolean allowAnyJavaType) {
-    if (isValidDataObjectType(type, isParam, isReturn)) {
+  private static boolean isValidNonCallableType(Element elem, TypeInfo type, boolean isParam, boolean isReturn, boolean allowParameterized, boolean allowAnyJavaType) {
+    if (isValidDataObjectType(elem, type, isParam, isReturn)) {
       return true;
     }
     if (type.getKind() == ClassKind.VOID) {
@@ -79,13 +80,13 @@ class TypeValidator {
     if (type.getKind() == ClassKind.OBJECT) {
       return true;
     }
-    if (isValidVertxGenInterface(type, allowParameterized, allowAnyJavaType)) {
+    if (isValidVertxGenInterface(elem, type, allowParameterized, allowAnyJavaType)) {
       return true;
     }
     if (isValidOtherType(type, allowAnyJavaType)) {
       return true;
     }
-    if (allowParameterized && isValidContainer(type, allowAnyJavaType)) {
+    if (allowParameterized && isValidContainer(elem, type, allowAnyJavaType)) {
       return true;
     }
     return false;
@@ -111,20 +112,20 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidDataObjectType(TypeInfo type, boolean isParam, boolean isReturn) {
+  private static boolean isValidDataObjectType(Element elem, TypeInfo type, boolean isParam, boolean isReturn) {
     if (type.isDataObjectHolder()) {
       if (isParam && !type.getDataObject().isDeserializable()) {
-        return false;
+        throw new GenException(elem, "@DataObject type " + type + " does not declare a required deserializable method when used in parameter");
       }
       if (isReturn && !type.getDataObject().isSerializable()) {
-        return false;
+        throw new GenException(elem, "@DataObject type " + type + " does not declare a required serializable method when used in return");
       }
       return true;
     }
     return false;
   }
 
-  private static boolean isValidContainer(TypeInfo type, boolean allowAnyJavaType) {
+  private static boolean isValidContainer(Element elem, TypeInfo type, boolean allowAnyJavaType) {
     TypeInfo argument = null;
     if (rawTypeIs(type, List.class, Set.class, Map.class)) {
       ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
@@ -134,22 +135,22 @@ class TypeValidator {
         argument= parameterizedType.getArgs().get(1);
       }
     }
-    return argument != null && isValidContainerComponent(argument, allowAnyJavaType);
+    return argument != null && isValidContainerComponent(elem, argument, allowAnyJavaType);
   }
 
-  private static boolean isValidContainerComponent(TypeInfo arg, boolean allowAnyJavaType) {
-    return isValidNonCallableType(arg, true, true, false, allowAnyJavaType);
+  private static boolean isValidContainerComponent(Element elem, TypeInfo arg, boolean allowAnyJavaType) {
+    return isValidNonCallableType(elem, arg, true, true, false, allowAnyJavaType);
   }
 
-  private static boolean isValidVertxGenTypeArgument(TypeInfo arg, boolean allowAnyJavaType) {
-    return isValidNonCallableType(arg, false, false, true, allowAnyJavaType);
+  private static boolean isValidVertxGenTypeArgument(Element elem, TypeInfo arg, boolean allowAnyJavaType) {
+    return isValidNonCallableType(elem, arg, false, false, true, allowAnyJavaType);
   }
 
   private static boolean isValidOtherType(TypeInfo type, boolean allowAnyJavaType) {
     return allowAnyJavaType && type.getKind() == ClassKind.OTHER;
   }
 
-  private static boolean isValidVertxGenInterface(TypeInfo type, boolean allowParameterized, boolean allowAnyJavaType) {
+  private static boolean isValidVertxGenInterface(Element elem, TypeInfo type, boolean allowParameterized, boolean allowAnyJavaType) {
     if (type.getKind() == ClassKind.API) {
       if (type.isParameterized()) {
         ParameterizedTypeInfo parameterized = (ParameterizedTypeInfo) type;
@@ -157,7 +158,7 @@ class TypeValidator {
           parameterized
             .getArgs()
             .stream()
-            .noneMatch(arg -> !isValidVertxGenTypeArgument(arg, allowAnyJavaType) || arg.isNullable());
+            .noneMatch(arg -> !isValidVertxGenTypeArgument(elem, arg, allowAnyJavaType) || arg.isNullable());
       } else {
         return true;
       }
@@ -165,25 +166,25 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidFunctionType(TypeInfo typeInfo, boolean allowAnyJavaType) {
+  private static boolean isValidFunctionType(Element elem, TypeInfo typeInfo, boolean allowAnyJavaType) {
     if (typeInfo.getErased().getKind() == ClassKind.FUNCTION) {
       TypeInfo paramType = ((ParameterizedTypeInfo) typeInfo).getArgs().get(0);
-      if (isValidCallbackValueType(paramType, allowAnyJavaType)) {
+      if (isValidCallbackValueType(elem, paramType, allowAnyJavaType)) {
         TypeInfo returnType = ((ParameterizedTypeInfo) typeInfo).getArgs().get(1);
-        return isValidNonCallableType(returnType, true, false, true, allowAnyJavaType);
+        return isValidNonCallableType(elem, returnType, true, false, true, allowAnyJavaType);
       }
     }
     return false;
   }
 
-  private static boolean isValidHandlerType(TypeInfo type, boolean allowAnyJavaType) {
+  private static boolean isValidHandlerType(Element elem, TypeInfo type, boolean allowAnyJavaType) {
     if (type.getErased().getKind() == ClassKind.HANDLER) {
       TypeInfo eventType = ((ParameterizedTypeInfo) type).getArgs().get(0);
-      if (isValidCallbackValueType(eventType, allowAnyJavaType)) {
+      if (isValidCallbackValueType(elem, eventType, allowAnyJavaType)) {
         return true;
       } else if (eventType.getErased().getKind() == ClassKind.ASYNC_RESULT && !eventType.isNullable()) {
         TypeInfo resultType = ((ParameterizedTypeInfo) eventType).getArgs().get(0);
-        if (isValidCallbackValueType(resultType, allowAnyJavaType)) {
+        if (isValidCallbackValueType(elem, resultType, allowAnyJavaType)) {
           return true;
         }
       }
@@ -191,8 +192,8 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidCallbackValueType(TypeInfo type, boolean allowAnyJavaType) {
-    return isValidNonCallableType(type, false, true, true, allowAnyJavaType);
+  private static boolean isValidCallbackValueType(Element elem, TypeInfo type, boolean allowAnyJavaType) {
+    return isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType);
   }
 
   private static boolean rawTypeIs(TypeInfo type, Class<?>... classes) {

--- a/src/main/java/io/vertx/codegen/TypeValidator.java
+++ b/src/main/java/io/vertx/codegen/TypeValidator.java
@@ -5,7 +5,6 @@ import io.vertx.codegen.type.ParameterizedTypeInfo;
 import io.vertx.codegen.type.TypeInfo;
 import io.vertx.codegen.type.TypeVariableInfo;
 
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
@@ -20,43 +19,63 @@ import java.util.Set;
 class TypeValidator {
 
   static void validateParamType(ExecutableElement elem, TypeInfo typeInfo, boolean allowAnyJavaType) {
-    if (isValidNonCallableType(elem, typeInfo, true, false, true, allowAnyJavaType)) {
-      return;
+    try {
+      if (isValidNonCallableType(typeInfo, true, false, true, allowAnyJavaType)) {
+        return;
+      }
+      if (isValidClassTypeParam(elem, typeInfo)) {
+        return;
+      }
+      if (isValidHandlerType(typeInfo, allowAnyJavaType)) {
+        return;
+      }
+      if (isValidFunctionType(typeInfo, allowAnyJavaType)) {
+        return;
+      }
+      throw new GenException(elem, "type " + typeInfo + " is not legal for use for a parameter in code generation");
+    } catch (IllegalStateException e) {
+      throw new GenException(elem, e.getMessage());
     }
-    if (isValidClassTypeParam(elem, typeInfo)) {
-      return;
-    }
-    if (isValidHandlerType(elem, typeInfo, allowAnyJavaType)) {
-      return;
-    }
-    if (isValidFunctionType(elem, typeInfo, allowAnyJavaType)) {
-      return;
-    }
-    throw new GenException(elem, "type " + typeInfo + " is not legal for use for a parameter in code generation");
   }
 
   static void validateReturnType(ExecutableElement elem, TypeInfo type, boolean allowAnyJavaType) {
-    if (type.isVoid()) {
-      return;
+    try {
+      if (type.isVoid()) {
+        return;
+      }
+      if (isValidNonCallableType(type, false, true, true, allowAnyJavaType)) {
+        return;
+      }
+      if (isValidHandlerType(type, allowAnyJavaType)) {
+        return;
+      }
+      throw new GenException(elem, "type " + type + " is not legal for use for a return type in code generation");
+    } catch (IllegalStateException e) {
+      throw new GenException(elem, e.getMessage());
     }
-    if (isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType)) {
-      return;
-    }
-    if (isValidHandlerType(elem, type, allowAnyJavaType)) {
-      return;
-    }
-    throw new GenException(elem, "type " + type + " is not legal for use for a return type in code generation");
   }
 
   static void validateConstantType(VariableElement elem, TypeInfo type, TypeMirror typeMirror, boolean allowAnyJavaType) {
-    if (isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType)) {
-      return;
+    try {
+      if (isValidNonCallableType(type, false, true, true, allowAnyJavaType)) {
+        return;
+      }
+      throw new GenException(elem, "type " + type + " is not legal for use for a constant type in code generation");
+    } catch (IllegalStateException e) {
+      throw new GenException(elem, e.getMessage());
     }
-    throw new GenException(elem, "type " + type + " is not legal for use for a constant type in code generation");
   }
 
-  private static boolean isValidNonCallableType(Element elem, TypeInfo type, boolean isParam, boolean isReturn, boolean allowParameterized, boolean allowAnyJavaType) {
-    if (isValidDataObjectType(elem, type, isParam, isReturn)) {
+  private static boolean isValidNonCallableType(TypeInfo type, boolean isParam, boolean isReturn, boolean allowParameterized, boolean allowAnyJavaType) {
+    if (type.isDataObjectHolder()) {
+      // data objects my be defined without serializer or deserializer
+      // however at this point this can be an illegal state as one or both are required
+      if (isParam && !type.getDataObject().isDeserializable()) {
+        throw new IllegalStateException("@DataObject " + type + " does not declare a serializer");
+      }
+      if (isReturn && !type.getDataObject().isSerializable()) {
+        throw new IllegalStateException("@DataObject " + type + " does not declare a deserializer");
+      }
       return true;
     }
     if (type.getKind() == ClassKind.VOID) {
@@ -80,13 +99,13 @@ class TypeValidator {
     if (type.getKind() == ClassKind.OBJECT) {
       return true;
     }
-    if (isValidVertxGenInterface(elem, type, allowParameterized, allowAnyJavaType)) {
+    if (isValidVertxGenInterface(type, allowParameterized, allowAnyJavaType)) {
       return true;
     }
     if (isValidOtherType(type, allowAnyJavaType)) {
       return true;
     }
-    if (allowParameterized && isValidContainer(elem, type, allowAnyJavaType)) {
+    if (allowParameterized && isValidContainer(type, allowAnyJavaType)) {
       return true;
     }
     return false;
@@ -112,20 +131,7 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidDataObjectType(Element elem, TypeInfo type, boolean isParam, boolean isReturn) {
-    if (type.isDataObjectHolder()) {
-      if (isParam && !type.getDataObject().isDeserializable()) {
-        throw new GenException(elem, "@DataObject type " + type + " does not declare a required deserializable method when used in parameter");
-      }
-      if (isReturn && !type.getDataObject().isSerializable()) {
-        throw new GenException(elem, "@DataObject type " + type + " does not declare a required serializable method when used in return");
-      }
-      return true;
-    }
-    return false;
-  }
-
-  private static boolean isValidContainer(Element elem, TypeInfo type, boolean allowAnyJavaType) {
+  private static boolean isValidContainer(TypeInfo type, boolean allowAnyJavaType) {
     TypeInfo argument = null;
     if (rawTypeIs(type, List.class, Set.class, Map.class)) {
       ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
@@ -135,22 +141,22 @@ class TypeValidator {
         argument= parameterizedType.getArgs().get(1);
       }
     }
-    return argument != null && isValidContainerComponent(elem, argument, allowAnyJavaType);
+    return argument != null && isValidContainerComponent(argument, allowAnyJavaType);
   }
 
-  private static boolean isValidContainerComponent(Element elem, TypeInfo arg, boolean allowAnyJavaType) {
-    return isValidNonCallableType(elem, arg, true, true, false, allowAnyJavaType);
+  private static boolean isValidContainerComponent(TypeInfo arg, boolean allowAnyJavaType) {
+    return isValidNonCallableType(arg, true, true, false, allowAnyJavaType);
   }
 
-  private static boolean isValidVertxGenTypeArgument(Element elem, TypeInfo arg, boolean allowAnyJavaType) {
-    return isValidNonCallableType(elem, arg, false, false, true, allowAnyJavaType);
+  private static boolean isValidVertxGenTypeArgument(TypeInfo arg, boolean allowAnyJavaType) {
+    return isValidNonCallableType(arg, false, false, true, allowAnyJavaType);
   }
 
   private static boolean isValidOtherType(TypeInfo type, boolean allowAnyJavaType) {
     return allowAnyJavaType && type.getKind() == ClassKind.OTHER;
   }
 
-  private static boolean isValidVertxGenInterface(Element elem, TypeInfo type, boolean allowParameterized, boolean allowAnyJavaType) {
+  private static boolean isValidVertxGenInterface(TypeInfo type, boolean allowParameterized, boolean allowAnyJavaType) {
     if (type.getKind() == ClassKind.API) {
       if (type.isParameterized()) {
         ParameterizedTypeInfo parameterized = (ParameterizedTypeInfo) type;
@@ -158,7 +164,7 @@ class TypeValidator {
           parameterized
             .getArgs()
             .stream()
-            .noneMatch(arg -> !isValidVertxGenTypeArgument(elem, arg, allowAnyJavaType) || arg.isNullable());
+            .noneMatch(arg -> !isValidVertxGenTypeArgument(arg, allowAnyJavaType) || arg.isNullable());
       } else {
         return true;
       }
@@ -166,25 +172,25 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidFunctionType(Element elem, TypeInfo typeInfo, boolean allowAnyJavaType) {
+  private static boolean isValidFunctionType(TypeInfo typeInfo, boolean allowAnyJavaType) {
     if (typeInfo.getErased().getKind() == ClassKind.FUNCTION) {
       TypeInfo paramType = ((ParameterizedTypeInfo) typeInfo).getArgs().get(0);
-      if (isValidCallbackValueType(elem, paramType, allowAnyJavaType)) {
+      if (isValidCallbackValueType(paramType, allowAnyJavaType)) {
         TypeInfo returnType = ((ParameterizedTypeInfo) typeInfo).getArgs().get(1);
-        return isValidNonCallableType(elem, returnType, true, false, true, allowAnyJavaType);
+        return isValidNonCallableType(returnType, true, false, true, allowAnyJavaType);
       }
     }
     return false;
   }
 
-  private static boolean isValidHandlerType(Element elem, TypeInfo type, boolean allowAnyJavaType) {
+  private static boolean isValidHandlerType(TypeInfo type, boolean allowAnyJavaType) {
     if (type.getErased().getKind() == ClassKind.HANDLER) {
       TypeInfo eventType = ((ParameterizedTypeInfo) type).getArgs().get(0);
-      if (isValidCallbackValueType(elem, eventType, allowAnyJavaType)) {
+      if (isValidCallbackValueType(eventType, allowAnyJavaType)) {
         return true;
       } else if (eventType.getErased().getKind() == ClassKind.ASYNC_RESULT && !eventType.isNullable()) {
         TypeInfo resultType = ((ParameterizedTypeInfo) eventType).getArgs().get(0);
-        if (isValidCallbackValueType(elem, resultType, allowAnyJavaType)) {
+        if (isValidCallbackValueType(resultType, allowAnyJavaType)) {
           return true;
         }
       }
@@ -192,8 +198,8 @@ class TypeValidator {
     return false;
   }
 
-  private static boolean isValidCallbackValueType(Element elem, TypeInfo type, boolean allowAnyJavaType) {
-    return isValidNonCallableType(elem, type, false, true, true, allowAnyJavaType);
+  private static boolean isValidCallbackValueType(TypeInfo type, boolean allowAnyJavaType) {
+    return isValidNonCallableType(type, false, true, true, allowAnyJavaType);
   }
 
   private static boolean rawTypeIs(TypeInfo type, Class<?>... classes) {

--- a/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -135,6 +135,8 @@ public class TypeMirrorFactory {
         } else {
           MapperInfo serializer = serializers.get(type.toString());
           MapperInfo deserializer = deserializers.get(type.toString());
+          DataObjectInfo dataObject = null;
+
           if (elt.getAnnotation(DataObject.class) != null) {
             ClassKind serializable = Helper.getAnnotatedDataObjectAnnotatedSerializationType(elementUtils, elt);
             ClassKind deserializable = Helper.getAnnotatedDataObjectDeserialisationType(elementUtils, typeUtils, elt);
@@ -160,12 +162,13 @@ public class TypeMirrorFactory {
                 deserializer.setTargetType(STRING);
               }
             }
-          }
-          DataObjectInfo dataObject = null;
-          if (serializer != null || deserializer != null) {
-            dataObject = new DataObjectInfo(
-              serializer,
-              deserializer);
+            dataObject = new DataObjectInfo(serializer, deserializer);
+          } else {
+            if (serializer != null || deserializer != null) {
+              dataObject = new DataObjectInfo(
+                serializer,
+                deserializer);
+            }
           }
           List<TypeParamInfo.Class> typeParams = createTypeParams(type);
           if (kind == ClassKind.API) {

--- a/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeReflectionFactory.java
@@ -90,7 +90,7 @@ public class TypeReflectionFactory {
               deserializer.setKind(MapperKind.SELF);
             }
             DataObjectInfo dataObject = null;
-            if (serializable || serializable) {
+            if (serializable || deserializable) {
               dataObject = new DataObjectInfo(serializer, deserializer);
             }
             return new ClassTypeInfo(kind, fqcn, module, false, typeParams, dataObject);


### PR DESCRIPTION
A few bugs are fixed with handling serializable/deserializable on data objects. As a second step better error messages are now provided to the user. For example:

```java
@DataObject
class DO {
}
```

Used on:

```java
@VertxGen
interface MyAPI {
  void method(Handler<AsyncResult<DO>> handler);
}
```

Which would before fail with the message:

```
"type DO is not legal for use for a parameter in code generation"
```

Will now report:

```
@DataObject type DO does not declare a required serializable method when used in return
```

It is now clear that the `DataObject` contract is incomplete and the user should either implement a `toJson()` method or add a custom serializer annotation.