### PR TITLE
Fix base64 codec

### DIFF
--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -2,6 +2,7 @@ package io.vertx.test.codegen.converter;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
@@ -83,7 +84,7 @@ public class TestDataObjectConverter {
           if (member.getValue() instanceof JsonArray) {
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                obj.addAddedBuffer(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)item)));
+                obj.addAddedBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
             });
           }
           break;
@@ -433,7 +434,7 @@ public class TestDataObjectConverter {
           break;
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
         case "bufferList":
@@ -441,7 +442,7 @@ public class TestDataObjectConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
             });
             obj.setBufferList(list);
           }
@@ -451,7 +452,7 @@ public class TestDataObjectConverter {
             java.util.Map<String, io.vertx.core.buffer.Buffer> map = new java.util.LinkedHashMap<>();
             ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
               if (entry.getValue() instanceof String)
-                map.put(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)entry.getValue())));
+                map.put(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)entry.getValue())));
             });
             obj.setBufferMap(map);
           }
@@ -461,7 +462,7 @@ public class TestDataObjectConverter {
             java.util.LinkedHashSet<io.vertx.core.buffer.Buffer> list =  new java.util.LinkedHashSet<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
             });
             obj.setBufferSet(list);
           }
@@ -674,7 +675,7 @@ public class TestDataObjectConverter {
           if (member.getValue() instanceof JsonObject) {
             ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
               if (entry.getValue() instanceof String)
-                obj.addKeyedBufferValue(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)entry.getValue())));
+                obj.addKeyedBufferValue(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)entry.getValue())));
             });
           }
           break;
@@ -1003,7 +1004,7 @@ public class TestDataObjectConverter {
     }
     if (obj.getAddedBuffers() != null) {
       JsonArray array = new JsonArray();
-      obj.getAddedBuffers().forEach(item -> array.add(java.util.Base64.getEncoder().encodeToString(item.getBytes())));
+      obj.getAddedBuffers().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("addedBuffers", array);
     }
     if (obj.getAddedHttpMethods() != null) {
@@ -1191,21 +1192,21 @@ public class TestDataObjectConverter {
       json.put("boxedShortValueMap", map);
     }
     if (obj.getBuffer() != null) {
-      json.put("buffer", java.util.Base64.getEncoder().encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
     if (obj.getBufferList() != null) {
       JsonArray array = new JsonArray();
-      obj.getBufferList().forEach(item -> array.add(java.util.Base64.getEncoder().encodeToString(item.getBytes())));
+      obj.getBufferList().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("bufferList", array);
     }
     if (obj.getBufferMap() != null) {
       JsonObject map = new JsonObject();
-      obj.getBufferMap().forEach((key, value) -> map.put(key, java.util.Base64.getEncoder().encodeToString(value.getBytes())));
+      obj.getBufferMap().forEach((key, value) -> map.put(key, JsonUtil.BASE64_ENCODER.encodeToString(value.getBytes())));
       json.put("bufferMap", map);
     }
     if (obj.getBufferSet() != null) {
       JsonArray array = new JsonArray();
-      obj.getBufferSet().forEach(item -> array.add(java.util.Base64.getEncoder().encodeToString(item.getBytes())));
+      obj.getBufferSet().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("bufferSet", array);
     }
     if (obj.getHttpMethod() != null) {
@@ -1322,7 +1323,7 @@ public class TestDataObjectConverter {
     }
     if (obj.getKeyedBufferValues() != null) {
       JsonObject map = new JsonObject();
-      obj.getKeyedBufferValues().forEach((key, value) -> map.put(key, java.util.Base64.getEncoder().encodeToString(value.getBytes())));
+      obj.getKeyedBufferValues().forEach((key, value) -> map.put(key, JsonUtil.BASE64_ENCODER.encodeToString(value.getBytes())));
       json.put("keyedBufferValues", map);
     }
     if (obj.getKeyedEnumValues() != null) {

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -62,6 +62,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.print("\n");
     writer.print("import io.vertx.core.json.JsonObject;\n");
     writer.print("import io.vertx.core.json.JsonArray;\n");
+    writer.print("import io.vertx.core.json.impl.JsonUtil;\n");
     writer.print("import java.time.Instant;\n");
     writer.print("import java.time.format.DateTimeFormatter;\n");
     writer.print("\n");
@@ -132,7 +133,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
             switch (propKind) {
               case API:
                 if (prop.getType().getName().equals("io.vertx.core.buffer.Buffer")) {
-                  genPropToJson("java.util.Base64.getEncoder().encodeToString(", ".getBytes())", prop, writer);
+                  genPropToJson("JsonUtil.BASE64_ENCODER.encodeToString(", ".getBytes())", prop, writer);
                 }
                 break;
               case ENUM:
@@ -265,7 +266,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
             switch (propKind) {
               case API:
                 if (prop.getType().getName().equals("io.vertx.core.buffer.Buffer")) {
-                  genPropFromJson("String", "io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)", "))", prop, writer);
+                  genPropFromJson("String", "io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)", "))", prop, writer);
                 }
                 break;
               case JSON_OBJECT:

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.impl;
+
+import java.util.Base64;
+
+/**
+ * Implementation utilities (details) affecting the way JSON objects are wrapped.
+ */
+public final class JsonUtil {
+
+  public static final Base64.Encoder BASE64_ENCODER;
+  public static final Base64.Decoder BASE64_DECODER;
+
+  static {
+    /*
+     * Vert.x 3.x Json supports RFC-7493, however the JSON encoder/decoder format was incorrect.
+     * Users who might need to interop with Vert.x 3.x applications should set the system property
+     * {@code vertx.json.base64} to {@code legacy}.
+     */
+    if ("legacy".equalsIgnoreCase(System.getProperty("vertx.json.base64"))) {
+      BASE64_ENCODER = Base64.getEncoder();
+      BASE64_DECODER = Base64.getDecoder();
+    } else {
+      BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+      BASE64_DECODER = Base64.getUrlDecoder();
+    }
+  }
+
+  /**
+   * Wraps well known java types to adhere to the Json expected types.
+   * <ul>
+   *   <li>{@code Map} will be wrapped to {@code JsonObject}</li>
+   *   <li>{@code List} will be wrapped to {@code JsonArray}</li>
+   *   <li>{@code Instant} will be converted to iso date {@code String}</li>
+   *   <li>{@code byte[]} will be converted to base64 {@code String}</li>
+   *   <li>{@code Enum} will be converted to enum name {@code String}</li>
+   * </ul>
+   *
+   * @param val java type
+   * @return wrapped type or {@code val} if not applicable.
+   */
+  public static Object wrapJsonValue(Object val) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static Object checkAndCopy(Object val) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
@@ -17,7 +18,7 @@ public class DataObjectWithBufferConverter {
       switch (member.getKey()) {
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
       }
@@ -30,7 +31,7 @@ public class DataObjectWithBufferConverter {
 
   public static void toJson(DataObjectWithBuffer obj, java.util.Map<String, Object> json) {
     if (obj.getBuffer() != null) {
-      json.put("buffer", java.util.Base64.getEncoder().encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
   }
 }

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
@@ -17,7 +18,7 @@ public class DataObjectWithNestedBufferConverter {
       switch (member.getKey()) {
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
         case "buffers":
@@ -25,7 +26,7 @@ public class DataObjectWithNestedBufferConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(java.util.Base64.getDecoder().decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
             });
             obj.setBuffers(list);
           }
@@ -45,11 +46,11 @@ public class DataObjectWithNestedBufferConverter {
 
   public static void toJson(DataObjectWithNestedBuffer obj, java.util.Map<String, Object> json) {
     if (obj.getBuffer() != null) {
-      json.put("buffer", java.util.Base64.getEncoder().encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
     if (obj.getBuffers() != null) {
       JsonArray array = new JsonArray();
-      obj.getBuffers().forEach(item -> array.add(java.util.Base64.getEncoder().encodeToString(item.getBytes())));
+      obj.getBuffers().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("buffers", array);
     }
     if (obj.getNested() != null) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
@@ -2,6 +2,7 @@ package io.vertx.codegen.testmodel;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 

--- a/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
+++ b/src/test/java/io/vertx/test/codegen/converter/DataObjectTest.java
@@ -14,6 +14,7 @@ package io.vertx.test.codegen.converter;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -571,7 +572,7 @@ public class DataObjectTest {
     assertEquals(Character.toString(boxedCharValue), json.get("boxedChar"));
     assertEquals(jsonObjectDataObject.toJson(), json.get("jsonObjectDataObject"));
     assertEquals(stringDataObject.toJson(), json.get("stringDataObject"));
-    assertEquals(buffer, Buffer.buffer(Base64.getDecoder().decode((String)json.get("buffer"))));
+    assertEquals(buffer, Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)json.get("buffer"))));
     assertEquals(jsonObject, json.get("jsonObject"));
     assertEquals(jsonArray, json.get("jsonArray"));
     assertEquals(httpMethod.name(), json.get("httpMethod"));
@@ -589,7 +590,7 @@ public class DataObjectTest {
     assertEquals(new JsonArray().add(Character.toString(boxedCharValue)), json.get("boxedCharList"));
     assertEquals(new JsonArray().add(jsonObjectDataObject.toJson()), json.get("jsonObjectDataObjectList"));
     assertEquals(new JsonArray().add(stringDataObject.toJson()), json.get("stringDataObjectList"));
-    assertEquals(Base64.getEncoder().encodeToString(buffer.getBytes()), ((JsonArray)json.get("bufferList")).getValue(0));
+    assertEquals(JsonUtil.BASE64_ENCODER.encodeToString(buffer.getBytes()), ((JsonArray)json.get("bufferList")).getValue(0));
     assertEquals(new JsonArray().add(jsonObject), json.get("jsonObjectList"));
     assertEquals(new JsonArray().add(jsonArray), json.get("jsonArrayList"));
     assertEquals(new JsonArray().add(httpMethod.name()), json.get("httpMethodList"));
@@ -608,7 +609,7 @@ public class DataObjectTest {
     assertEquals(new JsonArray().add(Character.toString(boxedCharValue)), json.get("boxedCharSet"));
     assertEquals(new JsonArray().add(jsonObjectDataObject.toJson()), json.get("jsonObjectDataObjectSet"));
     assertEquals(new JsonArray().add(stringDataObject.toJson()), json.get("stringDataObjectSet"));
-    assertEquals(Base64.getEncoder().encodeToString(buffer.getBytes()), ((JsonArray)json.get("bufferSet")).getValue(0));
+    assertEquals(JsonUtil.BASE64_ENCODER.encodeToString(buffer.getBytes()), ((JsonArray)json.get("bufferSet")).getValue(0));
     assertEquals(new JsonArray().add(jsonObject), json.get("jsonObjectSet"));
     assertEquals(new JsonArray().add(jsonArray), json.get("jsonArraySet"));
     assertEquals(new JsonArray().add(httpMethod.name()), json.get("httpMethodSet"));
@@ -627,7 +628,7 @@ public class DataObjectTest {
     assertEquals(new JsonObject().put(key, Character.toString(boxedCharValue)), json.get("boxedCharValueMap"));
     assertEquals(new JsonObject().put(key, jsonObjectDataObject.toJson()), json.get("jsonObjectDataObjectMap"));
     assertEquals(new JsonObject().put(key, stringDataObject.toJson()), json.get("stringDataObjectMap"));
-    assertEquals(Base64.getEncoder().encodeToString(buffer.getBytes()), ((JsonObject)json.get("bufferMap")).getValue(key));
+    assertEquals(JsonUtil.BASE64_ENCODER.encodeToString(buffer.getBytes()), ((JsonObject)json.get("bufferMap")).getValue(key));
     assertEquals(new JsonObject().put(key, jsonObject), json.get("jsonObjectMap"));
     assertEquals(new JsonObject().put(key, jsonArray), json.get("jsonArrayMap"));
     assertEquals(new JsonObject().put(key, httpMethod.name()), json.get("httpMethodMap"));
@@ -646,7 +647,7 @@ public class DataObjectTest {
     assertEquals(new JsonObject().put(key, Character.toString(boxedCharValue)), json.get("keyedBoxedCharValues"));
     assertEquals(new JsonObject().put(key, jsonObjectDataObject.toJson()), json.get("keyedJsonObjectDataObjectValues"));
     assertEquals(new JsonObject().put(key, stringDataObject.toJson()), json.get("keyedStringDataObjectValues"));
-    assertEquals(Base64.getEncoder().encodeToString(buffer.getBytes()), ((JsonObject)json.get("keyedBufferValues")).getValue(key));
+    assertEquals(JsonUtil.BASE64_ENCODER.encodeToString(buffer.getBytes()), ((JsonObject)json.get("keyedBufferValues")).getValue(key));
     assertEquals(new JsonObject().put(key, jsonObject), json.get("keyedJsonObjectValues"));
     assertEquals(new JsonObject().put(key, jsonArray), json.get("keyedJsonArrayValues"));
     assertEquals(new JsonObject().put(key, httpMethod.name()), json.get("keyedEnumValues"));
@@ -784,7 +785,7 @@ public class DataObjectTest {
   }
 
   private String toBase64(Buffer buffer) {
-    return Base64.getEncoder().encodeToString(buffer.getBytes());
+    return JsonUtil.BASE64_ENCODER.encodeToString(buffer.getBytes());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Core has been changed here:

https://github.com/eclipse-vertx/vert.x/pull/3197

To correctly implement the RFC7493

However codegen still used the wrong codec and there was no way to support the correct one.

This PR fixes the codegen to use the exact same codec as `core` and also respect the config flag to switch to the `old/legacy` codec if core also so does.
 