### PR TITLE
Ignore type annotations when searching for serializers / deserializers

### DIFF
--- a/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -133,8 +133,8 @@ public class TypeMirrorFactory {
             raw = new ClassTypeInfo(raw.kind, raw.name, raw.module, true, raw.params, null);
           }
         } else {
-          MapperInfo serializer = serializers.get(type.toString());
-          MapperInfo deserializer = deserializers.get(type.toString());
+          MapperInfo serializer = serializers.get(fqcn);
+          MapperInfo deserializer = deserializers.get(fqcn);
           DataObjectInfo dataObject = null;
           if (elt.getAnnotation(DataObject.class) != null) {
             ClassKind serializable = Helper.getAnnotatedDataObjectAnnotatedSerializationType(elementUtils, elt);

--- a/src/tck/java/io/vertx/codegen/testmodel/NullableTCK.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/NullableTCK.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,6 +110,13 @@ public interface NullableTCK {
   void methodWithNullableDataObjectHandler(boolean notNull, Handler<@Nullable TestDataObject> handler);
   void methodWithNullableDataObjectHandlerAsyncResult(boolean notNull, Handler<AsyncResult<@Nullable TestDataObject>> handler);
   @Nullable TestDataObject methodWithNullableDataObjectReturn(boolean notNull);
+
+  // Test @Nullable json-mapped type
+  boolean methodWithNonNullableJsonMappedParam(ZonedDateTime param);
+  void methodWithNullableJsonMappedParam(boolean expectNull, @Nullable ZonedDateTime param);
+  void methodWithNullableJsonMappedHandler(boolean notNull, Handler<@Nullable ZonedDateTime> handler);
+  void methodWithNullableJsonMappedHandlerAsyncResult(boolean notNull, Handler<AsyncResult<@Nullable ZonedDateTime>> handler);
+  @Nullable ZonedDateTime methodWithNullableJsonMappedReturn(boolean notNull);
 
   // Test @Nullable Enum type
   boolean methodWithNonNullableEnumParam(TestEnum param);

--- a/src/tck/java/io/vertx/codegen/testmodel/NullableTCKImpl.java
+++ b/src/tck/java/io/vertx/codegen/testmodel/NullableTCKImpl.java
@@ -11,6 +11,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -358,6 +362,35 @@ public class NullableTCKImpl implements NullableTCK {
   @Override
   public @Nullable TestDataObject methodWithNullableDataObjectReturn(boolean notNull) {
     return notNull ? new TestDataObject().setFoo("foo_value").setBar(12345).setWibble(3.5) : null;
+  }
+
+  @Override
+  public boolean methodWithNonNullableJsonMappedParam(ZonedDateTime param) {
+    return param == null;
+  }
+
+  @Override
+  public void methodWithNullableJsonMappedParam(boolean expectNull, @Nullable ZonedDateTime param) {
+    if (expectNull) {
+      assertNull(param);
+    } else {
+      assertEquals(methodWithNullableJsonMappedReturn(true), param);
+    }
+  }
+
+  @Override
+  public void methodWithNullableJsonMappedHandler(boolean notNull, Handler<@Nullable ZonedDateTime> handler) {
+    handler.handle(methodWithNullableJsonMappedReturn(notNull));
+  }
+
+  @Override
+  public void methodWithNullableJsonMappedHandlerAsyncResult(boolean notNull, Handler<AsyncResult<@Nullable ZonedDateTime>> handler) {
+    handler.handle(Future.succeededFuture(methodWithNullableJsonMappedReturn(notNull)));
+  }
+
+  @Override
+  public @Nullable ZonedDateTime methodWithNullableJsonMappedReturn(boolean notNull) {
+    return notNull ? LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()) : null;
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

When a type included an annotation such as @NonNull then TypeMirrorFactory tried to find a mapper using type.toString().

type.toString() included the annotation in the name as well which resulted in failing to find the appropriate mapper.

With these change the serializers / deserializers are found using the fqdn of the type only
 
