### PR TITLE
Issue#327 - Code generation not working with modules + JDK 16 

### DIFF
--- a/src/main/java/io/vertx/codegen/CodeGen.java
+++ b/src/main/java/io/vertx/codegen/CodeGen.java
@@ -69,15 +69,18 @@ public class CodeGen {
   public void init(RoundEnvironment round, ClassLoader loader) {
     loaderMap.put(env, loader);
     Predicate<Element> implFilter = elt -> {
-      PackageElement pkg;
       try {
-        pkg = elementUtils.getPackageOf(elt);
+        // Since JDK 16, method elementUtils.getPackageOf(Element)
+        // can return null instead of throwing a NPE.
+        return Optional.ofNullable(elementUtils.getPackageOf(elt))
+                       .map(pkg -> pkg.getQualifiedName().toString())
+                       .map(fqn -> !fqn.contains(".impl.") && !fqn.endsWith(".impl"))
+                       .orElse(true);
       } catch (NullPointerException e) {
-        // This might happen with JDK 11 using modules and it looks like a JDK bug
+        // This might happen with JDK 11 using modules and it looks
+        // like a JDK bug
         return true;
       }
-      String fqn = pkg.getQualifiedName().toString();
-      return !fqn.contains(".impl.") && !fqn.endsWith(".impl");
     };
 
     // Process serializers


### PR DESCRIPTION
Signed-off-by: Jérémy Florte <jeremy.florte@leroymerlin.fr>

Motivation:

Using a recent JDK (16), code generation does not work on project using modules (i.e java modules, declared in module-info.java files).

The aim of this P.R is to fix code generation, adding a control to a previous fix made for JDK 11 that used to throw a NPE (from JDK code) when accessing package elements. JDK 16 does not throw a NPE but returns `null` which was not handled and thus raised a NPE from the project code itself.

A test case would have been useful but it would require the project to compile with JDK 16, not true today.

The P.R code has been tested with JDK 11 and 16 on sample project provided in declared issue and initial use case project. 

_NB: conformance requirements done_


