### PR TITLE
Fix regression for Kotlin companion objects

### DIFF
--- a/src/test/java/io/vertx/test/codegen/ClassTest.java
+++ b/src/test/java/io/vertx/test/codegen/ClassTest.java
@@ -38,6 +38,8 @@ import io.vertx.test.codegen.testapi.javatypes.MethodWithValidJavaTypeParams;
 import io.vertx.test.codegen.testapi.javatypes.MethodWithValidJavaTypeReturn;
 import io.vertx.test.codegen.testapi.jsonmapper.MyPojo;
 import io.vertx.test.codegen.testapi.jsonmapper.WithMyPojo;
+import io.vertx.test.codegen.testapi.kotlin.InterfaceWithCompanionObject;
+import io.vertx.test.codegen.testapi.kotlin.InterfaceWithUnrelatedCompanionClass;
 import io.vertx.test.codegen.testapi.overloadcheck.OverloadCheckIgnoreEnhancedMethod;
 import io.vertx.test.codegen.testapi.overloadcheck.OverloadCheckInvalidMethodOverloading;
 import io.vertx.test.codegen.testapi.simple.InterfaceInImplContainingPackage;
@@ -2499,6 +2501,16 @@ public class ClassTest extends ClassTestBase {
     }
     ClassModel model = new GeneratorHelper().generateClass(InterfaceInImplContainingPackage.class);
     assertEquals(InterfaceInImplContainingPackage.class.getName(), model.getFqn());
+  }
+
+  @Test
+  public void testInterfaceWithKotlinCompanionObject() throws Exception {
+    ClassModel model = new GeneratorHelper().generateClass(InterfaceWithCompanionObject.class);
+  }
+
+  @Test(expected = GenException.class)
+  public void testInterfaceUnrelatedCompanionObject() throws Exception {
+    ClassModel model = new GeneratorHelper().generateClass(InterfaceWithUnrelatedCompanionClass.class);
   }
 
   @Test

--- a/src/test/java/io/vertx/test/codegen/testapi/kotlin/Companion.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/kotlin/Companion.java
@@ -1,0 +1,13 @@
+package io.vertx.test.codegen.testapi.kotlin;
+
+public final class Companion {
+  static final Companion $$INSTANCE;
+
+  public final void create() {
+  }
+
+  static {
+    Companion var0 = new Companion();
+    $$INSTANCE = var0;
+  }
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/kotlin/InterfaceWithCompanionObject.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/kotlin/InterfaceWithCompanionObject.java
@@ -1,0 +1,26 @@
+package io.vertx.test.codegen.testapi.kotlin;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Richard Gomez
+ */
+@VertxGen
+public interface InterfaceWithCompanionObject {
+
+  InterfaceWithCompanionObject.Companion Companion = InterfaceWithCompanionObject.Companion.$$INSTANCE;
+
+  @GenIgnore
+  public static final class Companion {
+    static final InterfaceWithCompanionObject.Companion $$INSTANCE;
+
+    public final void create() {
+    }
+
+    static {
+      InterfaceWithCompanionObject.Companion var0 = new InterfaceWithCompanionObject.Companion();
+      $$INSTANCE = var0;
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/kotlin/InterfaceWithUnrelatedCompanionClass.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/kotlin/InterfaceWithUnrelatedCompanionClass.java
@@ -1,0 +1,11 @@
+package io.vertx.test.codegen.testapi.kotlin;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Richard Gomez
+ */
+@VertxGen
+public interface InterfaceWithUnrelatedCompanionClass {
+  Companion CompanionField = Companion.$$INSTANCE;
+}


### PR DESCRIPTION
This is a duplicate of #229, which went stale and had a messy commit history.

> Simple workaround for [vert-x3/vertx-lang-kotlin#93](https://github.com/vert-x3/vertx-lang-kotlin/issues/93).
> 
> LMK if there's a better/more appropriate fix.


FYI @vietj 