### PR TITLE
Allow accessing the @Override annotation from codegen

### DIFF
--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -794,6 +794,7 @@ public class ClassModel implements Model {
     }
 
     boolean methodDeprecated = modelMethod.getAnnotation(Deprecated.class) != null || deprecatedDesc != null;
+    boolean methodOverride = modelMethod.getAnnotation(Override.class) != null;
     String methodName = modelMethod.getSimpleName().toString();
 
     MethodInfo methodInfo = createMethodInfo(
@@ -813,7 +814,8 @@ public class ClassModel implements Model {
       declaringElt,
       methodDeprecated,
       methodDeprecatedDesc,
-      getModule().useFutures);
+      getModule().useFutures,
+      methodOverride);
 
     // Check we don't hide another method, we don't check overrides but we are more
     // interested by situations like diamond inheritance of the same method, in this case
@@ -846,9 +848,9 @@ public class ClassModel implements Model {
                                         Text returnDescription,
                                         boolean isFluent, boolean isCacheReturn, List<ParamInfo> mParams,
                                         ExecutableElement methodElt, boolean isStatic, boolean isDefault, ArrayList<TypeParamInfo.Method> typeParams,
-                                        TypeElement declaringElt, boolean methodDeprecated, Text methodDeprecatedDesc, boolean useFutures) {
+                                        TypeElement declaringElt, boolean methodDeprecated, Text methodDeprecatedDesc, boolean useFutures, boolean methodOverride) {
     return new MethodInfo(ownerTypes, methodName, returnType, returnDescription,
-      isFluent, isCacheReturn, mParams, comment, doc, isStatic, isDefault, typeParams, methodDeprecated, methodDeprecatedDesc, useFutures);
+      isFluent, isCacheReturn, mParams, comment, doc, isStatic, isDefault, typeParams, methodDeprecated, methodDeprecatedDesc, useFutures, methodOverride);
   }
 
   // This is a hook to allow different model implementations to check methods in different ways

--- a/src/main/java/io/vertx/codegen/MethodInfo.java
+++ b/src/main/java/io/vertx/codegen/MethodInfo.java
@@ -48,11 +48,13 @@ public class MethodInfo implements Comparable<MethodInfo> {
   private boolean deprecated;
   private Text deprecatedDesc;
   private boolean useFutures;
+  private boolean methodOverride;
 
   public MethodInfo(Set<ClassTypeInfo> ownerTypes, String name,
                     TypeInfo returnType, Text returnDescription, boolean fluent,  boolean cacheReturn,
                     List<ParamInfo> params, String comment, Doc doc, boolean staticMethod, boolean defaultMethod,
-                    List<TypeParamInfo.Method> typeParams, boolean deprecated, Text deprecatedDesc, boolean useFutures) {
+                    List<TypeParamInfo.Method> typeParams, boolean deprecated, Text deprecatedDesc, boolean useFutures,
+                    boolean methodOverride) {
 
     this.useFutures = useFutures;
     this.comment = comment;
@@ -69,6 +71,7 @@ public class MethodInfo implements Comparable<MethodInfo> {
     this.ownerTypes = ownerTypes;
     this.deprecated = deprecated;
     this.deprecatedDesc = deprecatedDesc;
+    this.methodOverride = methodOverride;
   }
 
   public String getName() {
@@ -318,6 +321,10 @@ public class MethodInfo implements Comparable<MethodInfo> {
     return useFutures;
   }
 
+  public boolean isMethodOverride() {
+    return methodOverride;
+  }
+
   /**
    * @return the description of deprecated
    */
@@ -373,7 +380,8 @@ public class MethodInfo implements Comparable<MethodInfo> {
       new ArrayList<>(typeParams),
       deprecated,
       deprecatedDesc,
-      useFutures);
+      useFutures,
+      methodOverride);
   }
 
   @Override

--- a/src/test/java/io/vertx/test/codegen/OverrideTest.java
+++ b/src/test/java/io/vertx/test/codegen/OverrideTest.java
@@ -1,0 +1,34 @@
+package io.vertx.test.codegen;
+
+import io.vertx.codegen.*;
+import io.vertx.test.codegen.testapi.DeprecatedInterface;
+import io.vertx.test.codegen.testapi.GenericInterface;
+import io.vertx.test.codegen.testapi.OverrideA;
+import io.vertx.test.codegen.testapi.OverrideB;
+import io.vertx.test.codegen.testdataobject.DataObjectWithProperty;
+import io.vertx.test.codegen.testdataobject.DeprecatedDataObject;
+import io.vertx.test.codegen.testenum.DeprecatedEnum;
+import io.vertx.test.codegen.testenum.ValidEnum;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OverrideTest {
+  private GeneratorHelper generator = new GeneratorHelper();
+
+  @Test
+  public void testVertxGenBaseOverride() throws Exception {
+    ClassModel model = generator.generateClass(OverrideA.class);
+    MethodInfo method = model.getMethods().get(0);
+    // Base class should not be annotated
+    assertFalse(method.isMethodOverride());
+  }
+
+  @Test
+  public void testVertxGenOverride() throws Exception {
+    ClassModel model = generator.generateClass(OverrideB.class);
+    MethodInfo method = model.getMethods().get(0);
+    // child class should be annotated
+    assertTrue(method.isMethodOverride());
+  }
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/OverrideA.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/OverrideA.java
@@ -1,0 +1,9 @@
+package io.vertx.test.codegen.testapi;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface OverrideA {
+
+  void someMethod();
+}

--- a/src/test/java/io/vertx/test/codegen/testapi/OverrideB.java
+++ b/src/test/java/io/vertx/test/codegen/testapi/OverrideB.java
@@ -1,0 +1,10 @@
+package io.vertx.test.codegen.testapi;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface OverrideB extends OverrideA {
+
+  @Override
+  void someMethod();
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

When working with codegen it is useful to know when a method to be generated overrides a base class/interface method.

Now that typescript supports this too, we can add more type information to `es4x` or any of the other `codegen` generators.

This change should not affect any existing generator as it doesn't introduce any breaking change, and generators can now make use of the `isMethodOverride()` flag in `MethodInfo` to further customize the generated code as needed.
