### PR TITLE
Allow data objects to fallback to Base64 basic for Buffer encode/decode

### DIFF
--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildInheritingDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.ChildInheritingDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class ChildInheritingDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ChildInheritingDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ChildNotInheritingDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.ChildNotInheritingDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class ChildNotInheritingDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ChildNotInheritingDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesDeserializerWithFromJsonDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.ConverterGeneratesDeserializerWithFromJsonDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class ConverterGeneratesDeserializerWithFromJsonDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ConverterGeneratesDeserializerWithFromJsonDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ConverterGeneratesSerializerWithToJsonDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.ConverterGeneratesSerializerWithToJsonDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class ConverterGeneratesSerializerWithToJsonDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ConverterGeneratesSerializerWithToJsonDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/ParentDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.ParentDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class ParentDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ParentDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SetterAdderDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.SetterAdderDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class SetterAdderDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SetterAdderDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/SnakeFormattedDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.SnakeFormattedDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class SnakeFormattedDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SnakeFormattedDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
+++ b/src/converters/generated/io/vertx/test/codegen/converter/TestDataObjectConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.test.codegen.converter.TestDataObject}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class TestDataObjectConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TestDataObject obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -84,7 +93,7 @@ public class TestDataObjectConverter {
           if (member.getValue() instanceof JsonArray) {
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                obj.addAddedBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
+                obj.addAddedBuffer(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
             });
           }
           break;
@@ -434,7 +443,7 @@ public class TestDataObjectConverter {
           break;
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
         case "bufferList":
@@ -442,7 +451,7 @@ public class TestDataObjectConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
             });
             obj.setBufferList(list);
           }
@@ -452,7 +461,7 @@ public class TestDataObjectConverter {
             java.util.Map<String, io.vertx.core.buffer.Buffer> map = new java.util.LinkedHashMap<>();
             ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
               if (entry.getValue() instanceof String)
-                map.put(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)entry.getValue())));
+                map.put(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)entry.getValue())));
             });
             obj.setBufferMap(map);
           }
@@ -462,7 +471,7 @@ public class TestDataObjectConverter {
             java.util.LinkedHashSet<io.vertx.core.buffer.Buffer> list =  new java.util.LinkedHashSet<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
             });
             obj.setBufferSet(list);
           }
@@ -675,7 +684,7 @@ public class TestDataObjectConverter {
           if (member.getValue() instanceof JsonObject) {
             ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
               if (entry.getValue() instanceof String)
-                obj.addKeyedBufferValue(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)entry.getValue())));
+                obj.addKeyedBufferValue(entry.getKey(), io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)entry.getValue())));
             });
           }
           break;
@@ -1004,7 +1013,7 @@ public class TestDataObjectConverter {
     }
     if (obj.getAddedBuffers() != null) {
       JsonArray array = new JsonArray();
-      obj.getAddedBuffers().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getAddedBuffers().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("addedBuffers", array);
     }
     if (obj.getAddedHttpMethods() != null) {
@@ -1192,21 +1201,21 @@ public class TestDataObjectConverter {
       json.put("boxedShortValueMap", map);
     }
     if (obj.getBuffer() != null) {
-      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
     if (obj.getBufferList() != null) {
       JsonArray array = new JsonArray();
-      obj.getBufferList().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getBufferList().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("bufferList", array);
     }
     if (obj.getBufferMap() != null) {
       JsonObject map = new JsonObject();
-      obj.getBufferMap().forEach((key, value) -> map.put(key, JsonUtil.BASE64_ENCODER.encodeToString(value.getBytes())));
+      obj.getBufferMap().forEach((key, value) -> map.put(key, BASE64_ENCODER.encodeToString(value.getBytes())));
       json.put("bufferMap", map);
     }
     if (obj.getBufferSet() != null) {
       JsonArray array = new JsonArray();
-      obj.getBufferSet().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getBufferSet().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("bufferSet", array);
     }
     if (obj.getHttpMethod() != null) {
@@ -1323,7 +1332,7 @@ public class TestDataObjectConverter {
     }
     if (obj.getKeyedBufferValues() != null) {
       JsonObject map = new JsonObject();
-      obj.getKeyedBufferValues().forEach((key, value) -> map.put(key, JsonUtil.BASE64_ENCODER.encodeToString(value.getBytes())));
+      obj.getKeyedBufferValues().forEach((key, value) -> map.put(key, BASE64_ENCODER.encodeToString(value.getBytes())));
       json.put("keyedBufferValues", map);
     }
     if (obj.getKeyedEnumValues() != null) {

--- a/src/main/java/io/vertx/codegen/DataObjectModel.java
+++ b/src/main/java/io/vertx/codegen/DataObjectModel.java
@@ -52,6 +52,7 @@ public class DataObjectModel implements Model {
   private boolean generateConverter;
   private boolean inheritConverter;
   private boolean publicConverter;
+  private boolean base64UrlBuffers;
   private int constructors;
   // ----------------
   private boolean deprecated;
@@ -149,6 +150,10 @@ public class DataObjectModel implements Model {
     return publicConverter;
   }
 
+  public boolean isBase64UrlBuffers() {
+    return base64UrlBuffers;
+  }
+
   public boolean isSerializable() { return type.isDataObjectHolder() && type.getDataObject().isSerializable(); }
 
   public boolean isDeserializable() { return type.isDataObjectHolder() && type.getDataObject().isDeserializable(); }
@@ -188,6 +193,7 @@ public class DataObjectModel implements Model {
     vars.put("generateConverter", generateConverter);
     vars.put("inheritConverter", inheritConverter);
     vars.put("publicConverter", publicConverter);
+    vars.put("base64UrlBuffers", base64UrlBuffers);
     vars.put("concrete", concrete);
     vars.put("isClass", isClass);
     vars.put("properties", propertyMap.values());
@@ -226,6 +232,7 @@ public class DataObjectModel implements Model {
     this.generateConverter = ann.generateConverter();
     this.publicConverter = ann.publicConverter();
     this.inheritConverter = ann.inheritConverter();
+    this.base64UrlBuffers = ann.base64BasicBuffers();
     this.isClass = modelElt.getKind() == ElementKind.CLASS;
     this.concrete = isClass && !modelElt.getModifiers().contains(Modifier.ABSTRACT);
     try {

--- a/src/main/java/io/vertx/codegen/annotations/DataObject.java
+++ b/src/main/java/io/vertx/codegen/annotations/DataObject.java
@@ -81,4 +81,9 @@ public @interface DataObject {
    */
   Class<? extends Case> jsonPropertyNameFormatter() default LowerCamelCase.class;
 
+  /**
+   * @return true if buffers codec should default to base64 basic encoding.
+   * Default {@code false}, use the platform default.
+   */
+  boolean base64BasicBuffers() default false;
 }

--- a/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
+++ b/src/main/java/io/vertx/codegen/generators/dataobjecthelper/DataObjectHelperGen.java
@@ -67,6 +67,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
     writer.print("import io.vertx.core.json.impl.JsonUtil;\n");
     writer.print("import java.time.Instant;\n");
     writer.print("import java.time.format.DateTimeFormatter;\n");
+    writer.print("import java.util.Base64;\n");
     writer.print("\n");
     writer.print("/**\n");
     writer.print(" * Converter and mapper for {@link " + model.getType() + "}.\n");
@@ -77,6 +78,24 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
       ).newLine();
     if (model.getGenerateConverter()) {
       writer.print("\n");
+
+      writer.print(
+        "  private static final Base64.Decoder BASE64_DECODER;\n" +
+        "  private static final Base64.Encoder BASE64_ENCODER;\n" +
+        "\n" +
+        "  static {\n");
+      if (model.isBase64UrlBuffers()) {
+        writer.print(
+          "    BASE64_DECODER = Base64.getDecoder();\n" +
+          "    BASE64_ENCODER = Base64.getEncoder();\n");
+      } else {
+        writer.print(
+          "    BASE64_DECODER = JsonUtil.BASE64_DECODER;\n" +
+          "    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;\n");
+      }
+      writer.print("  }\n");
+      writer.print("\n");
+
       genFromJson(visibility, inheritConverter, model, writer);
       writer.print("\n");
       genToJson(visibility, inheritConverter, model, writer);
@@ -135,7 +154,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
             switch (propKind) {
               case API:
                 if (prop.getType().getName().equals("io.vertx.core.buffer.Buffer")) {
-                  genPropToJson("JsonUtil.BASE64_ENCODER.encodeToString(", ".getBytes())", prop, writer);
+                  genPropToJson("BASE64_ENCODER.encodeToString(", ".getBytes())", prop, writer);
                 }
                 break;
               case ENUM:
@@ -268,7 +287,7 @@ public class DataObjectHelperGen extends Generator<DataObjectModel> {
             switch (propKind) {
               case API:
                 if (prop.getType().getName().equals("io.vertx.core.buffer.Buffer")) {
-                  genPropFromJson("String", "io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)", "))", prop, writer);
+                  genPropFromJson("String", "io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)", "))", prop, writer);
                 }
                 break;
               case JSON_OBJECT:

--- a/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
+++ b/src/main/java/io/vertx/codegen/type/TypeMirrorFactory.java
@@ -10,7 +10,6 @@ import javax.lang.model.type.*;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithBufferConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithBuffer}.
@@ -13,12 +14,20 @@ import java.time.format.DateTimeFormatter;
 public class DataObjectWithBufferConverter {
 
 
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
+
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithBuffer obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
       }
@@ -31,7 +40,7 @@ public class DataObjectWithBufferConverter {
 
   public static void toJson(DataObjectWithBuffer obj, java.util.Map<String, Object> json) {
     if (obj.getBuffer() != null) {
-      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
   }
 }

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListAddersConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithListAdders}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithListAddersConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithListAdders obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithListsConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithLists}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithListsConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithLists obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapAddersConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithMapAdders}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithMapAddersConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithMapAdders obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithMapsConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithMaps}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithMapsConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithMaps obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithNestedBufferConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithNestedBuffer}.
@@ -13,12 +14,20 @@ import java.time.format.DateTimeFormatter;
 public class DataObjectWithNestedBufferConverter {
 
 
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
+
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithNestedBuffer obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
         case "buffers":
@@ -26,7 +35,7 @@ public class DataObjectWithNestedBufferConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
             });
             obj.setBuffers(list);
           }
@@ -46,11 +55,11 @@ public class DataObjectWithNestedBufferConverter {
 
   public static void toJson(DataObjectWithNestedBuffer obj, java.util.Map<String, Object> json) {
     if (obj.getBuffer() != null) {
-      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
+      json.put("buffer", BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
     if (obj.getBuffers() != null) {
       JsonArray array = new JsonArray();
-      obj.getBuffers().forEach(item -> array.add(JsonUtil.BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getBuffers().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
       json.put("buffers", array);
     }
     if (obj.getNested() != null) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithOnlyJsonObjectConstructorConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithOnlyJsonObjectConstructor}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithOnlyJsonObjectConstructorConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithOnlyJsonObjectConstructor obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithRecursionConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithRecursion}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithRecursionConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithRecursion obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
+++ b/src/tck/generated/io/vertx/codegen/testmodel/DataObjectWithValuesConverter.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.impl.JsonUtil;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.codegen.testmodel.DataObjectWithValues}.
@@ -12,6 +13,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class DataObjectWithValuesConverter {
 
+
+  private static final Base64.Decoder BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER;
+
+  static {
+    BASE64_DECODER = JsonUtil.BASE64_DECODER;
+    BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+  }
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DataObjectWithValues obj) {
     for (java.util.Map.Entry<String, Object> member : json) {


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Vert.x uses base64url as default alphabet for all internal binary encode/decode representation of buffers. This default is also know as I-JSON and has a well known RFC.

OpenAPI on the other hand, specifies that binary data encoded as Base64 should use the basic alphabet. While this isn't a problem it becomes problematic when users expect that generated code respects the contract expectations.

The problem this PR tries to solve is give a way for end users to be able to choose the `DataObject` specific base64 alphabet for a given type.

To address this, users who wish to use basic base64 as default alphabet on their POJOs, should mark the DataObjects as:

```
@DataObject(generateConverter = true, base64BasicBuffers = true)
class MyDataObject {
  ...
}
```

This will switch the alphabet of the buffer fields from the vertx default to `Base64 Basic`.

The PR is a follow up of the discussion: https://github.com/vert-x3/vertx-web/issues/1993 